### PR TITLE
Point site to coinshownearme.com custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+coinshownearme.com

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: "Coin Shows Near Me — US Coin Show Directory"
 description: "Find coin shows near you. Complete directory of 90+ coin shows across all 50 US states with dates, venues, and organizer details."
-url: "https://nezumitora.github.io"
-baseurl: "/coin-shows-near-me"
+url: "https://coinshownearme.com"
+baseurl: ""
 
 remote_theme: just-the-docs/just-the-docs
 
@@ -25,7 +25,7 @@ nav_external_links: []
 
 aux_links:
   "Melt Calculator":
-    - "/coin-shows-near-me/tools/melt-value-calculator/"
+    - "/tools/melt-value-calculator/"
 aux_links_new_tab: false
 
 google_site_verification: ZW60JDUpZFD9rhZv8KgiklQ65RSr5jyyxku3686lHbo

--- a/embed-generator.html
+++ b/embed-generator.html
@@ -241,7 +241,7 @@
       // ----------------------------------------
       // WHERE THE WIDGET LIVES
       // ----------------------------------------
-      const BASE_WIDGET_URL = "https://nezumitora.github.io/coin-shows-near-me/widget.html";
+      const BASE_WIDGET_URL = "https://coinshownearme.com/widget.html";
 
       const dealerNameInput = document.getElementById("eg-dealer-name");
       const dealerEmailInput = document.getElementById("eg-dealer-email");

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ The most complete directory of coin shows in the United States. Find upcoming co
 
 ## Find Coin Shows This Weekend
 
-Looking for a coin show happening soon? Check our **[Coin Shows This Weekend](/coin-shows-near-me/coin-shows-this-weekend/)** page for shows happening in the next few days.
+Looking for a coin show happening soon? Check our **[Coin Shows This Weekend](/coin-shows-this-weekend/)** page for shows happening in the next few days.
 
 ---
 

--- a/legal/index.md
+++ b/legal/index.md
@@ -10,6 +10,6 @@ breadcrumb_current: "Legal"
 
 # Legal
 
-- [Terms of Use](/coin-shows-near-me/legal/terms-of-use/) — Your agreement with the Platform, including limitation of liability, indemnification, and dispute resolution.
-- [Privacy Policy](/coin-shows-near-me/legal/privacy-policy/) — How we collect, use, and protect your personal information.
-- [Disclaimer](/coin-shows-near-me/legal/disclaimer/) — Important disclaimers regarding transactions, appraisals, event listings, and dealer verification.
+- [Terms of Use](/legal/terms-of-use/) — Your agreement with the Platform, including limitation of liability, indemnification, and dispute resolution.
+- [Privacy Policy](/legal/privacy-policy/) — How we collect, use, and protect your personal information.
+- [Disclaimer](/legal/disclaimer/) — Important disclaimers regarding transactions, appraisals, event listings, and dealer verification.

--- a/widget.html
+++ b/widget.html
@@ -405,7 +405,7 @@
       // ------------------------------------
       const CONFIG = {
         // IMPORTANT: Update this!
-        showsJsonUrl: "https://nezumitora.github.io/coin-shows-near-me/shows.json",
+        showsJsonUrl: "https://coinshownearme.com/shows.json",
         poweredByName: "YourBrand",
         poweredByUrl: "https://yourbrand.com"
       };


### PR DESCRIPTION
## Summary

- Add `CNAME` file with `coinshownearme.com` to enable GitHub Pages custom domain
- Update `_config.yml`: url + baseurl for custom domain
- Fix all hardcoded `/coin-shows-near-me/` path prefixes across 4 files
- Update widget + embed-generator to use `coinshownearme.com` URLs

## DNS (done in Namecheap)

4x A records pointing to GitHub Pages IPs + 1x CNAME for www → nezumitora.github.io