### PR TITLE
Add live spot metal prices with hourly updates

### DIFF
--- a/.github/workflows/update-spot-prices.yml
+++ b/.github/workflows/update-spot-prices.yml
@@ -1,0 +1,77 @@
+name: Update Spot Prices
+
+on:
+  schedule:
+    # Run every hour at :05 past
+    - cron: '5 * * * *'
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  update-prices:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch spot prices
+        run: |
+          mkdir -p assets/data
+
+          # Fetch all four metals from gold-api.com (no API key needed)
+          GOLD=$(curl -sf "https://api.gold-api.com/price/XAU" || echo '{}')
+          SILVER=$(curl -sf "https://api.gold-api.com/price/XAG" || echo '{}')
+          PLATINUM=$(curl -sf "https://api.gold-api.com/price/XPT" || echo '{}')
+          PALLADIUM=$(curl -sf "https://api.gold-api.com/price/XPD" || echo '{}')
+
+          # Extract prices (jq installed on ubuntu-latest)
+          GOLD_PRICE=$(echo "$GOLD" | jq -r '.price // empty')
+          SILVER_PRICE=$(echo "$SILVER" | jq -r '.price // empty')
+          PLATINUM_PRICE=$(echo "$PLATINUM" | jq -r '.price // empty')
+          PALLADIUM_PRICE=$(echo "$PALLADIUM" | jq -r '.price // empty')
+
+          # Only write if we got at least gold and silver
+          if [ -z "$GOLD_PRICE" ] || [ -z "$SILVER_PRICE" ]; then
+            echo "::warning::Failed to fetch gold or silver price. Skipping update."
+            exit 0
+          fi
+
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          cat > assets/data/spot-prices.json <<EOF
+          {
+            "gold": ${GOLD_PRICE},
+            "silver": ${SILVER_PRICE},
+            "platinum": ${PLATINUM_PRICE:-null},
+            "palladium": ${PALLADIUM_PRICE:-null},
+            "currency": "USD",
+            "source": "gold-api.com",
+            "updated_at": "${TIMESTAMP}"
+          }
+          EOF
+
+          # Clean up indentation (heredoc adds leading spaces)
+          python3 -c "
+          import json, sys
+          with open('assets/data/spot-prices.json') as f:
+              data = json.load(f)
+          with open('assets/data/spot-prices.json', 'w') as f:
+              json.dump(data, f, indent=2)
+              f.write('\n')
+          "
+
+          echo "Prices updated: Gold=$GOLD_PRICE Silver=$SILVER_PRICE Platinum=$PLATINUM_PRICE Palladium=$PALLADIUM_PRICE"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/data/spot-prices.json
+          if git diff --cached --quiet; then
+            echo "No price changes to commit."
+          else
+            git commit -m "chore: update spot prices [skip ci]"
+            git push
+          fi

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -225,4 +225,63 @@
 .site-footer {
   display: none !important;
 }
+
+/* Spot price ticker bar */
+.spot-ticker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+  background: var(--coin-navy);
+  color: #e2e8f0;
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  font-size: 0.85rem;
+  border: 1px solid rgba(218, 165, 32, 0.3);
+}
+.spot-ticker-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: nowrap;
+}
+.spot-ticker-label {
+  color: #94a3b8;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+.spot-ticker-price {
+  color: var(--coin-gold-light);
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+.spot-ticker-sep {
+  color: #475569;
+  font-size: 0.7rem;
+}
+.spot-ticker-updated {
+  color: #64748b;
+  font-size: 0.7rem;
+  width: 100%;
+  text-align: center;
+  margin-top: 0.1rem;
+}
+.spot-ticker-updated a {
+  color: #64748b !important;
+  text-decoration: none;
+}
+@media (max-width: 600px) {
+  .spot-ticker {
+    gap: 0.4rem;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8rem;
+  }
+  .spot-ticker-price {
+    font-size: 0.85rem;
+  }
+}
 </style>

--- a/assets/data/spot-prices.json
+++ b/assets/data/spot-prices.json
@@ -1,0 +1,9 @@
+{
+  "gold": 4789.70,
+  "silver": 78.67,
+  "platinum": 2093.00,
+  "palladium": 1579.00,
+  "currency": "USD",
+  "source": "gold-api.com",
+  "updated_at": "2026-04-17T00:09:00Z"
+}

--- a/index.md
+++ b/index.md
@@ -30,6 +30,29 @@ Thank you! We'll notify you when we launch. If you submitted a show or question,
 </div>
 </div>
 
+<div class="spot-ticker" id="spot-ticker" style="display:none;">
+  <div class="spot-ticker-item">
+    <span class="spot-ticker-label">Gold</span>
+    <span class="spot-ticker-price" id="spot-gold-price">--</span>
+  </div>
+  <span class="spot-ticker-sep">|</span>
+  <div class="spot-ticker-item">
+    <span class="spot-ticker-label">Silver</span>
+    <span class="spot-ticker-price" id="spot-silver-price">--</span>
+  </div>
+  <span class="spot-ticker-sep">|</span>
+  <div class="spot-ticker-item">
+    <span class="spot-ticker-label">Platinum</span>
+    <span class="spot-ticker-price" id="spot-platinum-price">--</span>
+  </div>
+  <span class="spot-ticker-sep">|</span>
+  <div class="spot-ticker-item">
+    <span class="spot-ticker-label">Palladium</span>
+    <span class="spot-ticker-price" id="spot-palladium-price">--</span>
+  </div>
+  <div class="spot-ticker-updated" id="spot-ticker-updated"></div>
+</div>
+
 The most complete directory of coin shows in the United States. Find upcoming coin shows, numismatic conventions, and coin expos near you — with dates, venues, and details for every show.
 
 ---
@@ -135,6 +158,43 @@ if (form) {
     });
   });
 }
+</script>
+
+<script>
+// Load spot prices from pre-fetched JSON (updated hourly by GitHub Actions)
+(function() {
+  function formatPrice(price) {
+    if (price == null) return '--';
+    return '$' + price.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  }
+  function timeAgo(dateStr) {
+    var now = new Date();
+    var then = new Date(dateStr);
+    var mins = Math.round((now - then) / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return mins + ' min ago';
+    var hrs = Math.round(mins / 60);
+    if (hrs < 24) return hrs + ' hr' + (hrs > 1 ? 's' : '') + ' ago';
+    var days = Math.round(hrs / 24);
+    return days + ' day' + (days > 1 ? 's' : '') + ' ago';
+  }
+  fetch('/assets/data/spot-prices.json')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      document.getElementById('spot-gold-price').textContent = formatPrice(data.gold);
+      document.getElementById('spot-silver-price').textContent = formatPrice(data.silver);
+      document.getElementById('spot-platinum-price').textContent = formatPrice(data.platinum);
+      document.getElementById('spot-palladium-price').textContent = formatPrice(data.palladium);
+      var updated = data.updated_at ? 'Updated ' + timeAgo(data.updated_at) + ' · Spot prices per troy oz' : 'Spot prices per troy oz';
+      document.getElementById('spot-ticker-updated').textContent = updated;
+      document.getElementById('spot-ticker').style.display = 'flex';
+      // Store prices globally for the melt calculator link
+      window.SPOT_PRICES = data;
+    })
+    .catch(function() {
+      // Silently fail — ticker stays hidden
+    });
+})();
 </script>
 
 <script type="application/ld+json">

--- a/tools/melt-value-calculator.html
+++ b/tools/melt-value-calculator.html
@@ -130,7 +130,30 @@ breadcrumb_current: "Melt Value Calculator"
 
 # Coin Melt Value Calculator
 
-Calculate the **metal melt value** of your US silver and gold coins instantly. Enter the current spot price and the number of coins you have — the calculator does the rest.
+Calculate the **metal melt value** of your US silver and gold coins instantly. Spot prices are loaded automatically and updated every hour — or enter your own.
+
+<div class="spot-ticker" id="calc-spot-ticker" style="display:none;">
+  <div class="spot-ticker-item">
+    <span class="spot-ticker-label">Gold</span>
+    <span class="spot-ticker-price" id="calc-spot-gold-display">--</span>
+  </div>
+  <span class="spot-ticker-sep">|</span>
+  <div class="spot-ticker-item">
+    <span class="spot-ticker-label">Silver</span>
+    <span class="spot-ticker-price" id="calc-spot-silver-display">--</span>
+  </div>
+  <span class="spot-ticker-sep">|</span>
+  <div class="spot-ticker-item">
+    <span class="spot-ticker-label">Platinum</span>
+    <span class="spot-ticker-price" id="calc-spot-platinum-display">--</span>
+  </div>
+  <span class="spot-ticker-sep">|</span>
+  <div class="spot-ticker-item">
+    <span class="spot-ticker-label">Palladium</span>
+    <span class="spot-ticker-price" id="calc-spot-palladium-display">--</span>
+  </div>
+  <div class="spot-ticker-updated" id="calc-spot-updated"></div>
+</div>
 
 <div class="calc-container">
 
@@ -139,14 +162,14 @@ Calculate the **metal melt value** of your US silver and gold coins instantly. E
 
 <div class="field-group">
   <label class="field-label" for="spot-silver">Silver Spot Price ($/oz)</label>
-  <input class="field-input" type="number" id="spot-silver" step="0.01" value="32.00" min="0">
-  <div class="spot-note">Enter today's silver spot price per troy ounce.</div>
+  <input class="field-input" type="number" id="spot-silver" step="0.01" value="78.67" min="0">
+  <div class="spot-note" id="silver-spot-note">Loading live price...</div>
 </div>
 
 <div class="field-group">
   <label class="field-label" for="spot-gold">Gold Spot Price ($/oz)</label>
-  <input class="field-input" type="number" id="spot-gold" step="0.01" value="2350.00" min="0">
-  <div class="spot-note">Enter today's gold spot price per troy ounce.</div>
+  <input class="field-input" type="number" id="spot-gold" step="0.01" value="4789.70" min="0">
+  <div class="spot-note" id="gold-spot-note">Loading live price...</div>
 </div>
 
 <h3 style="margin:1rem 0 0.5rem;font-size:1rem;">Silver Coins (90% Silver, Pre-1965)</h3>
@@ -406,6 +429,55 @@ Calculate the **metal melt value** of your US silver and gold coins instantly. E
     offerForm.style.display = 'none';
     offerSuccess.style.display = 'block';
   });
+
+  // Auto-load spot prices from pre-fetched JSON
+  function formatTickerPrice(price) {
+    if (price == null) return '--';
+    return '$' + price.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  }
+  function timeAgo(dateStr) {
+    var now = new Date();
+    var then = new Date(dateStr);
+    var mins = Math.round((now - then) / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return mins + ' min ago';
+    var hrs = Math.round(mins / 60);
+    if (hrs < 24) return hrs + ' hr' + (hrs > 1 ? 's' : '') + ' ago';
+    var days = Math.round(hrs / 24);
+    return days + ' day' + (days > 1 ? 's' : '') + ' ago';
+  }
+
+  fetch('/assets/data/spot-prices.json')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      // Update calculator input fields
+      if (data.silver) {
+        document.getElementById('spot-silver').value = data.silver.toFixed(2);
+        document.getElementById('silver-spot-note').textContent = 'Live price loaded · Updated ' + timeAgo(data.updated_at);
+      } else {
+        document.getElementById('silver-spot-note').textContent = 'Enter today\'s silver spot price per troy ounce.';
+      }
+      if (data.gold) {
+        document.getElementById('spot-gold').value = data.gold.toFixed(2);
+        document.getElementById('gold-spot-note').textContent = 'Live price loaded · Updated ' + timeAgo(data.updated_at);
+      } else {
+        document.getElementById('gold-spot-note').textContent = 'Enter today\'s gold spot price per troy ounce.';
+      }
+
+      // Update ticker display
+      var el = function(id) { return document.getElementById(id); };
+      el('calc-spot-gold-display').textContent = formatTickerPrice(data.gold);
+      el('calc-spot-silver-display').textContent = formatTickerPrice(data.silver);
+      el('calc-spot-platinum-display').textContent = formatTickerPrice(data.platinum);
+      el('calc-spot-palladium-display').textContent = formatTickerPrice(data.palladium);
+      var updated = data.updated_at ? 'Updated ' + timeAgo(data.updated_at) + ' · Spot prices per troy oz' : 'Spot prices per troy oz';
+      el('calc-spot-updated').textContent = updated;
+      el('calc-spot-ticker').style.display = 'flex';
+    })
+    .catch(function() {
+      document.getElementById('silver-spot-note').textContent = 'Enter today\'s silver spot price per troy ounce.';
+      document.getElementById('gold-spot-note').textContent = 'Enter today\'s gold spot price per troy ounce.';
+    });
 })();
 </script>
 
@@ -432,7 +504,7 @@ Not sure about the silver content of your coins? Here's a quick reference:
 
 The **melt value** of a coin is the value of the precious metal it contains, based on the current spot price. It represents the minimum intrinsic value of a coin — what the metal itself would be worth if melted down.
 
-For example, a pre-1965 Washington quarter contains approximately 0.1808 troy ounces of silver. If silver is trading at $32/oz, that quarter's melt value is about $5.79 — regardless of its face value of $0.25.
+For example, a pre-1965 Washington quarter contains approximately 0.1808 troy ounces of silver. If silver is trading at $78/oz, that quarter's melt value is about $14.11 — regardless of its face value of $0.25.
 
 ### Melt Value vs. Collector Value
 


### PR DESCRIPTION
## Summary

- **GitHub Actions workflow** fetches gold, silver, platinum, and palladium spot prices from gold-api.com every hour (no API key needed)
- Prices are written to `assets/data/spot-prices.json` — visitors load a static file, zero API calls per page view
- **Homepage spot price ticker bar** displays all 4 metals with gold-themed styling and "updated X ago" timestamp
- **Melt calculator auto-loads** current spot prices on page load (users can still manually override)
- Graceful degradation: if JSON fails to load, ticker stays hidden and calculator uses last-known defaults

## Files Changed

- `NEW: .github/workflows/update-spot-prices.yml` — hourly cron workflow
- `NEW: assets/data/spot-prices.json` — seed data (workflow updates this)
- `EDIT: _includes/head_custom.html` — spot ticker CSS
- `EDIT: index.md` — ticker bar HTML + JS loader
- `EDIT: tools/melt-value-calculator.html` — auto-load prices, ticker bar, updated example text

## Why

Live spot prices add unique, frequently-updated content that search engines value. It also makes the melt calculator immediately useful without requiring users to look up prices elsewhere — reducing bounce rate and increasing time on site.