### PR TITLE
SEO hardening: fix sitemap URL, 404 page, internal linking, meta tags

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,46 @@
+---
+layout: default
+title: "Page Not Found"
+permalink: /404.html
+nav_exclude: true
+search_exclude: true
+---
+
+<div style="text-align:center;padding:2rem 1rem;">
+  <h1 style="font-size:3rem;color:#b8860b;margin-bottom:0.5rem;">404</h1>
+  <h2 style="color:#1a2332;margin-top:0;">Page Not Found</h2>
+  <p style="color:#6b7280;font-size:1.05rem;max-width:500px;margin:1rem auto;">
+    The page you're looking for doesn't exist or may have moved. Try one of these instead:
+  </p>
+
+  <div style="display:flex;flex-wrap:wrap;gap:0.75rem;justify-content:center;margin:2rem 0;">
+    <a href="/" style="display:inline-block;padding:0.6rem 1.25rem;background:#b8860b;color:#fff !important;border-radius:6px;text-decoration:none;font-weight:600;">
+      Browse All Coin Shows
+    </a>
+    <a href="/states/" style="display:inline-block;padding:0.6rem 1.25rem;background:#1a2332;color:#fff !important;border-radius:6px;text-decoration:none;font-weight:600;">
+      Shows by State
+    </a>
+    <a href="/coin-shows-this-weekend/" style="display:inline-block;padding:0.6rem 1.25rem;background:#2c3e50;color:#fff !important;border-radius:6px;text-decoration:none;font-weight:600;">
+      This Weekend
+    </a>
+    <a href="/tools/melt-value-calculator/" style="display:inline-block;padding:0.6rem 1.25rem;background:#daa520;color:#fff !important;border-radius:6px;text-decoration:none;font-weight:600;">
+      Melt Value Calculator
+    </a>
+  </div>
+
+  <h3 style="color:#1a2332;margin-top:2rem;">Popular States</h3>
+  <div style="display:flex;flex-wrap:wrap;gap:0.5rem;justify-content:center;margin:1rem 0;">
+    <a href="/states/california/">California</a> &middot;
+    <a href="/states/florida/">Florida</a> &middot;
+    <a href="/states/texas/">Texas</a> &middot;
+    <a href="/states/new-york/">New York</a> &middot;
+    <a href="/states/pennsylvania/">Pennsylvania</a> &middot;
+    <a href="/states/ohio/">Ohio</a> &middot;
+    <a href="/states/illinois/">Illinois</a> &middot;
+    <a href="/states/michigan/">Michigan</a>
+  </div>
+
+  <p style="color:#6b7280;font-size:0.85rem;margin-top:2rem;">
+    Looking for a specific show? Use the search bar above or <a href="/#notify-form">contact us</a>.
+  </p>
+</div>

--- a/_includes/seo-meta.html
+++ b/_includes/seo-meta.html
@@ -1,10 +1,12 @@
 {% if page.seo_title %}
 <title>{{ page.seo_title }}</title>
 <meta property="og:title" content="{{ page.seo_title }}">
+<meta name="twitter:title" content="{{ page.seo_title }}">
 {% endif %}
 {% if page.seo_description %}
 <meta name="description" content="{{ page.seo_description }}">
 <meta property="og:description" content="{{ page.seo_description }}">
+<meta name="twitter:description" content="{{ page.seo_description }}">
 {% endif %}
 <meta property="og:type" content="website">
 <meta property="og:locale" content="en_US">
@@ -16,3 +18,9 @@
 <meta property="og:url" content="{{ site.url }}{{ site.baseurl }}{{ page.url }}">
 {% endif %}
 <meta property="og:site_name" content="Coin Show Near Me">
+<meta property="og:image" content="{{ site.url }}{{ site.baseurl }}/assets/images/logo.png">
+<meta property="og:image:width" content="200">
+<meta property="og:image:height" content="200">
+<meta property="og:image:alt" content="Coin Show Near Me — US Coin Show Directory">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:image" content="{{ site.url }}{{ site.baseurl }}/assets/images/logo.png">

--- a/_layouts/city.html
+++ b/_layouts/city.html
@@ -29,6 +29,9 @@ layout: default
 <h2>About Coin Shows in {{ page.city_name }}</h2>
 <p>{{ page.city_name }}, {{ page.state_name }} hosts coin shows where collectors and dealers gather to buy, sell, and trade coins, currency, bullion, and numismatic collectibles. Whether you're a seasoned numismatist or just getting started, attending a local coin show is one of the best ways to find deals, get appraisals, and connect with the collecting community.</p>
 
+<h2>Bringing Coins to Sell?</h2>
+<p>Use our free <a href="{{ site.baseurl }}/tools/melt-value-calculator/">Melt Value Calculator</a> to check the metal value of your silver and gold coins before attending a show in {{ page.city_name }}.</p>
+
 <h2>Tips for Attending Coin Shows in {{ page.city_name }}</h2>
 <ul>
   <li><strong>Arrive early</strong> for the best selection — many dealers offer first picks to early birds.</li>
@@ -37,3 +40,6 @@ layout: default
   <li><strong>Ask questions</strong> — dealers are usually happy to educate and share knowledge.</li>
   <li><strong>Check dates before traveling</strong> — venues and schedules can change.</li>
 </ul>
+
+<h2>Find Shows This Weekend</h2>
+<p>Looking for a coin show happening soon? Check <a href="{{ site.baseurl }}/coin-shows-this-weekend/">coin shows this weekend</a> across the entire United States.</p>

--- a/_layouts/show.html
+++ b/_layouts/show.html
@@ -66,8 +66,13 @@ layout: default
   <li>Networking with local and regional collectors</li>
 </ul>
 
+<h2>Bringing Coins to Sell?</h2>
+<p>Use our <a href="{{ site.baseurl }}/tools/melt-value-calculator/">Melt Value Calculator</a> to calculate the metal value of your silver and gold coins before attending. Knowing the melt value gives you a baseline for negotiations with dealers.</p>
+
 <h2>More Coin Shows Near {{ show.city }}</h2>
 <p>See all <a href="{{ site.baseurl }}/cities/{{ show.city_slug }}/">coin shows in {{ show.city }}</a> or browse <a href="{{ site.baseurl }}/states/{% for state in site.data.states %}{% if state.abbrev == show.state %}{{ state.slug }}{% endif %}{% endfor %}/">all coin shows in {{ show.state_name }}</a>.</p>
+
+<p>Looking for a show happening soon? Check <a href="{{ site.baseurl }}/coin-shows-this-weekend/">coin shows this weekend</a> for events in the next few days.</p>
 
 <p style="margin-top:1.5rem;padding:0.75rem;background:#fef3c7;border-radius:0.5rem;font-size:0.9rem;">
   <strong>Dates and venues can change.</strong> Always verify details on the official show or club website before traveling.

--- a/_layouts/state.html
+++ b/_layouts/state.html
@@ -33,5 +33,11 @@ layout: default
 </ul>
 {% endif %}
 
+<h2>Bringing Coins to Sell?</h2>
+<p>Use our free <a href="{{ site.baseurl }}/tools/melt-value-calculator/">Melt Value Calculator</a> to check the metal value of your silver and gold coins before attending a show in {{ page.state_name }}. Knowing the melt value gives you a baseline for negotiations.</p>
+
+<h2>Coin Shows This Weekend</h2>
+<p>Looking for something happening soon? Check <a href="{{ site.baseurl }}/coin-shows-this-weekend/">coin shows this weekend</a> across the entire US.</p>
+
 <h2>Find Coin Shows in Other States</h2>
 <p>Browse our <a href="{{ site.baseurl }}/states/">complete list of coin shows by state</a>, or visit the <a href="{{ site.baseurl }}/">homepage</a> to search all upcoming shows across the United States.</p>

--- a/coin-shows-this-weekend.md
+++ b/coin-shows-this-weekend.md
@@ -19,3 +19,5 @@ Weekend coin shows are the perfect opportunity to:
 - **Support your local coin collecting community**
 
 Most coin shows are free to attend and welcome everyone from first-time visitors to experienced collectors.
+
+**Planning to sell?** Check our <a href="/tools/melt-value-calculator/">Melt Value Calculator</a> to see what your silver and gold coins are worth at today's spot prices before you go.

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://nezumitora.github.io/coin-shows-near-me/sitemap.xml
+Sitemap: https://coinshownearme.com/sitemap.xml


### PR DESCRIPTION
## Summary

- **Fix critical robots.txt bug** — sitemap URL was pointing to the old `nezumitora.github.io/coin-shows-near-me/` domain instead of `coinshownearme.com`. Search engines couldn't find the sitemap at the live domain.
- **Custom 404 page** with prominent links to homepage, states, weekend shows, and melt calculator. Includes popular state links for internal link equity.
- **Internal linking improvements** across all 244+ pages:
  - Show pages: added "Bringing Coins to Sell?" section linking to melt calculator, plus weekend page link
  - State pages: added melt calculator link and weekend page link
  - City pages: added melt calculator link and weekend page link
  - Weekend page: added melt calculator cross-link
- **Open Graph + Twitter Card meta tags** — added `og:image`, `og:image:alt`, `twitter:card`, `twitter:image`, and `twitter:title`/`twitter:description` for better social sharing previews

## Files Changed

- `FIX: robots.txt` — sitemap URL corrected to coinshownearme.com
- `NEW: 404.html` — custom 404 page with navigation aids
- `EDIT: _includes/seo-meta.html` — OG image + Twitter Card tags
- `EDIT: _layouts/show.html` — melt calculator + weekend links
- `EDIT: _layouts/state.html` — melt calculator + weekend links
- `EDIT: _layouts/city.html` — melt calculator + weekend links
- `EDIT: coin-shows-this-weekend.md` — melt calculator link

## Why

The broken sitemap URL was preventing search engines from discovering all 244 pages efficiently. Internal linking distributes page authority (PageRank) across the site — every show, state, and city page now links to the melt calculator and weekend page, and vice versa. OG/Twitter tags ensure the site looks professional when shared on social media.