### PR TITLE
Add FAQ schema markup for Google rich results

### DIFF
--- a/index.md
+++ b/index.md
@@ -211,3 +211,60 @@ if (form) {
   }
 }
 </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is a coin show?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A coin show (also called a coin expo, coin convention, or numismatic bourse) is an event where coin dealers, collectors, and enthusiasts gather to buy, sell, and trade coins, paper currency, bullion, tokens, and other numismatic collectibles. Shows range from small local events with a handful of tables to major national conventions with hundreds of dealers."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are coin shows free to attend?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most local and regional coin shows are free to attend. Some larger national conventions may charge an admission fee, typically $5-$10 for a day pass. Many shows offer free admission for children and students."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should I bring to a coin show?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Bring cash (most dealers prefer it and offer discounts), a loupe or magnifying glass to examine coins, any coins you want to sell or get appraised, and a budget you're comfortable with. A small notebook is also useful for tracking prices and dealer information."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I sell coins at a coin show?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, coin shows are one of the best places to sell coins. Multiple dealers under one roof means you can get competing offers. Most dealers will give free appraisals and make offers on the spot. Use our Melt Value Calculator to know the minimum metal value of your silver and gold coins before attending."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I find coin shows near me?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Coin Show Near Me maintains a directory of 90+ recurring coin shows across all 50 US states. Browse by state, check our 'This Weekend' page for upcoming events, or use the search to find shows in your area. Always verify dates on the official show website before traveling, as schedules can change."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the melt value of a coin?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The melt value is the value of the precious metal content in a coin based on current spot prices. For example, a pre-1965 Washington quarter contains 0.1808 troy ounces of silver. Melt value is the minimum intrinsic value — many coins are worth more due to rarity, condition, and collector demand. Use our free Melt Value Calculator to check your coins."
+      }
+    }
+  ]
+}
+</script>

--- a/tools/melt-value-calculator.html
+++ b/tools/melt-value-calculator.html
@@ -537,3 +537,44 @@ Coin shows are the best place to get competitive offers on your coins. Multiple 
   }
 }
 </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the melt value of a coin?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The melt value of a coin is the value of the precious metal it contains, based on the current spot price. It represents the minimum intrinsic value of a coin — what the metal itself would be worth if melted down. For example, a pre-1965 Washington quarter contains approximately 0.1808 troy ounces of silver."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between melt value and collector value?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Melt value is the floor price for a coin — the value of its metal content alone. Many coins are worth significantly more than melt value due to rarity, condition (grade), key dates, and collector demand. For example, Morgan silver dollars typically sell well above melt value because of their popularity with collectors."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How much silver is in a pre-1965 quarter?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pre-1965 Washington quarters contain 90% silver and have approximately 0.1808 troy ounces of silver content. At current spot prices, this makes each quarter worth significantly more than its 25-cent face value."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Where is the best place to sell silver and gold coins?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Coin shows are one of the best places to sell coins because multiple dealers under one roof means you can get competing offers. Use our Melt Value Calculator to know the minimum metal value before selling, and bring your coins to a local coin show for the best prices."
+      }
+    }
+  ]
+}
+</script>


### PR DESCRIPTION
## Summary

- **Homepage FAQ schema** — 6 structured Q&A items covering: what is a coin show, are they free, what to bring, can I sell coins, how to find shows near me, what is melt value
- **Melt calculator FAQ schema** — 4 structured Q&A items covering: what is melt value, melt vs collector value, silver content in pre-1965 quarters, best place to sell coins

## Why

FAQ structured data (`FAQPage` schema) enables Google's rich results — expandable Q&A snippets directly in search results. This increases:
- **SERP real estate** — FAQ results take up more vertical space, pushing competitors down
- **Click-through rate** — users see answers inline and click through for more detail
- **Keyword coverage** — each FAQ answer targets long-tail queries (e.g., "how much silver is in a quarter")

The content already existed on these pages in prose form. This PR wraps it in the schema markup Google needs to display it as rich results.

## Files Changed

- `EDIT: index.md` — added `FAQPage` JSON-LD block with 6 questions
- `EDIT: tools/melt-value-calculator.html` — added `FAQPage` JSON-LD block with 4 questions