### PR TITLE
Add version number to sidebar

### DIFF
--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,0 +1,1 @@
+<p class="site-version">v0.1.0</p>

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -221,9 +221,21 @@
   font-size: 0.9rem;
 }
 
-/* Footer credit override */
+/* Footer — hide theme credit, show version */
 .site-footer {
+  font-size: 0 !important;
+  line-height: 0 !important;
+  color: transparent !important;
+}
+.site-footer a {
   display: none !important;
+}
+.site-version {
+  font-size: 0.7rem !important;
+  color: #475569 !important;
+  margin: 0;
+  padding: 0.25rem 0;
+  letter-spacing: 0.05em;
 }
 
 /* Spot price ticker bar */


### PR DESCRIPTION
## Summary

Adds **v0.1.0** in the lower-left sidebar (dark navy pane) so the user can confirm they're seeing the latest deployment after a hard refresh.

- Created `_includes/footer_custom.html` with version display (just-the-docs theme hook)
- Hid the default "Just the Docs" theme credit text via CSS while keeping the footer container visible for the version
- Version shows as small gray text at the bottom of the sidebar nav

Version will be bumped with each deployment so the user can verify cache busting.