### PR TITLE
Move version to sidebar nav pane (v0.2.0)

### DIFF
--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,1 +1,0 @@
-<p class="site-version">v0.1.0</p>

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -221,20 +221,17 @@
   font-size: 0.9rem;
 }
 
-/* Footer — hide theme credit, show version */
+/* Footer credit — hide completely */
 .site-footer {
-  font-size: 0 !important;
-  line-height: 0 !important;
-  color: transparent !important;
-}
-.site-footer a {
   display: none !important;
 }
+
+/* Version number in sidebar nav */
 .site-version {
-  font-size: 0.7rem !important;
-  color: #475569 !important;
+  font-size: 0.7rem;
+  color: #475569;
   margin: 0;
-  padding: 0.25rem 0;
+  padding: 0.75rem 1rem 0.5rem;
   letter-spacing: 0.05em;
 }
 

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,0 +1,1 @@
+<div class="site-version">v0.2.0</div>


### PR DESCRIPTION
Moves version number from the white content footer into the dark navy sidebar nav area, below the navigation links. Bumped to v0.2.0.