### PR TITLE
Fix sidebar version, button visibility, portal copy (v0.3.0)

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -221,18 +221,34 @@
   font-size: 0.9rem;
 }
 
-/* Footer credit — hide completely */
-.site-footer {
-  display: none !important;
+/* Sidebar footer — show version, hide theme credit */
+.side-bar .site-footer {
+  display: block !important;
+  font-size: 0;
+  line-height: 0;
+  overflow: hidden;
+}
+/* Hide the bottom-of-page footer (mobile) theme credit */
+footer .d-md-none {
+  font-size: 0;
+  line-height: 0;
+  overflow: hidden;
 }
 
-/* Version number in sidebar nav */
+/* Version number */
 .site-version {
-  font-size: 0.7rem;
-  color: #475569;
+  font-size: 0.7rem !important;
+  color: #64748b !important;
   margin: 0;
-  padding: 0.75rem 1rem 0.5rem;
+  padding: 0.25rem 0;
   letter-spacing: 0.05em;
+  line-height: 1.4 !important;
+}
+
+/* CTA buttons — override gold link color */
+.cta-btn {
+  color: #fff !important;
+  text-decoration: none !important;
 }
 
 /* Spot price ticker bar */

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,1 +1,1 @@
-<div class="site-version">v0.2.0</div>
+<div class="site-version">v0.3.0</div>

--- a/index.md
+++ b/index.md
@@ -144,13 +144,13 @@ Know of a coin show not in our directory? Use the form at the top of this page t
 
 ---
 
-## Dealer Portal — Coming Soon
+## Get Quotes on Your Collection Before the Show
 
 <div style="background:linear-gradient(135deg, var(--coin-navy) 0%, var(--coin-navy-light) 100%);color:#f1f5f9;padding:1.25rem;border-radius:8px;margin:1rem 0;border-left:4px solid var(--coin-gold);">
-<p style="margin:0 0 0.5rem;font-size:1rem;"><strong style="color:var(--coin-gold-light);">We're building a dealer portal</strong> to connect verified coin dealers with collectors before the show.</p>
-<p style="margin:0 0 0.75rem;font-size:0.9rem;color:#cbd5e1;">Upload your collection, get pre-show offers, and skip the table-to-table walk.</p>
+<p style="margin:0 0 0.5rem;font-size:1rem;"><strong style="color:var(--coin-gold-light);">Dealer Portal — Coming Soon</strong></p>
+<p style="margin:0 0 0.75rem;font-size:0.9rem;color:#cbd5e1;">Upload photos of your coins, pick a show you're attending, and get offers from verified dealers before you walk through the door. No more lugging your collection table to table.</p>
 <p style="margin:0;">
-<a href="/portal/" style="display:inline-block;background:var(--coin-gold);color:#fff;padding:0.5rem 1.25rem;border-radius:6px;font-weight:600;font-size:0.9rem;text-decoration:none;">Learn More &rarr;</a>
+<a href="/portal/" class="cta-btn" style="display:inline-block;background:var(--coin-gold);padding:0.5rem 1.25rem;border-radius:6px;font-weight:600;font-size:0.9rem;">Find Out More &rarr;</a>
 </p>
 </div>
 


### PR DESCRIPTION
## Summary — three fixes

1. **Version number now in sidebar (navy pane)** — was hidden by `display:none` on `.site-footer`. Now the sidebar footer is visible with the theme credit text hidden via `font-size:0`, and only the version div shows through. Mobile bottom footer gets the same treatment.

2. **Gold "Learn More" button text now visible** — the global CSS rule `.main-content a { color: var(--coin-gold) !important; }` was overriding the inline `color:#fff`, making gold text on a gold button (invisible). Fixed by adding a `.cta-btn` class with `color: #fff !important` that beats the global rule.

3. **Dealer Portal section rewritten** — heading changed from "Dealer Portal — Coming Soon" to "Get Quotes on Your Collection Before the Show" (the action, not the feature name). Subheading is now the "Dealer Portal — Coming Soon" label. Description rewritten to be user-benefit focused. Button changed to "Find Out More".

Version bumped to **v0.3.0**.