### PR TITLE
Fix button text visibility + add page footer (v0.4.0)

### DIFF
--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,0 +1,11 @@
+<div class="page-footer">
+  <div class="footer-links">
+    <a href="/legal/terms-of-use/">Terms of Use</a> |
+    <a href="/legal/privacy-policy/">Privacy Policy</a> |
+    <a href="/legal/disclaimer/">Disclaimer</a> |
+    <a href="/legal/">Legal</a>
+  </div>
+  <div class="footer-copy">
+    &copy; {{ site.time | date: '%Y' }} Coin Show Near Me &mdash; All rights reserved.
+  </div>
+</div>

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -245,10 +245,40 @@ footer .d-md-none {
   line-height: 1.4 !important;
 }
 
-/* CTA buttons — override gold link color */
-.cta-btn {
+/* CTA buttons — override gold link color (needs .main-content scope to beat .main-content a) */
+.main-content a.cta-btn,
+a.cta-btn {
   color: #fff !important;
   text-decoration: none !important;
+}
+.main-content a.cta-btn:hover,
+a.cta-btn:hover {
+  color: #f1f5f9 !important;
+}
+
+/* Content-area page footer */
+.page-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--coin-border);
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--coin-muted);
+}
+.page-footer a {
+  color: var(--coin-muted) !important;
+  text-decoration: none;
+  margin: 0 0.5rem;
+}
+.page-footer a:hover {
+  color: var(--coin-gold) !important;
+}
+.page-footer .footer-links {
+  margin-bottom: 0.5rem;
+}
+.page-footer .footer-copy {
+  font-size: 0.7rem;
+  color: #9ca3af;
 }
 
 /* Spot price ticker bar */

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,1 +1,1 @@
-<div class="site-version">v0.3.0</div>
+<div class="site-version">v0.4.0</div>


### PR DESCRIPTION
## Summary

- **Fix button text**: `.cta-btn` CSS had lower specificity than `.main-content a` — both used `!important` but `.main-content a` (0-1-1) beats `.cta-btn` (0-1-0). Fixed by using `.main-content a.cta-btn` selector. The "Find Out More" button text will now render white on the gold background instead of invisible gold-on-gold.
- **Add page footer**: Created `footer_custom.html` (just-the-docs include) with legal links (Terms, Privacy, Disclaimer) and copyright line. Styled with `.page-footer` CSS — muted grey, centered, subtle border-top separator.
- **Version bump**: v0.3.0 → v0.4.0

## Files Changed

- `_includes/head_custom.html` — fixed `.cta-btn` specificity, added `.page-footer` CSS
- `_includes/footer_custom.html` — NEW: site-wide content-area footer with legal links
- `_includes/nav_footer_custom.html` — version bump to v0.4.0