### PR TITLE
Enrich show data: +26 venues, +11 websites, +1 new show

### DIFF
--- a/_data/shows.yml
+++ b/_data/shows.yml
@@ -196,10 +196,10 @@
   state_name: California
   city: Cupertino
   city_slug: cupertino-ca
-  venue: ''
+  venue: 10110 N DeAnza Blvd, Cupertino, CA
   frequency: Annual
   next_date: TBD
-  website: ''
+  website: https://www.cupertinocoinclub.org
   organizer: ''
   notes: ''
 - id: fremont-coin-club-show
@@ -244,7 +244,7 @@
   state_name: California
   city: Sacramento
   city_slug: sacramento-ca
-  venue: ''
+  venue: 3410 Westover Street, Sacramento, CA
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -280,10 +280,10 @@
   state_name: California
   city: Santa Clara
   city_slug: santa-clara-ca
-  venue: ''
+  venue: American Legion Post 419, 958 Homestead Road, Santa Clara, CA
   frequency: Recurring
   next_date: TBD
-  website: ''
+  website: https://www.santaclaracoinshow.com
   organizer: ''
   notes: ''
 - id: valley-coin-show
@@ -475,7 +475,7 @@
   venue: ''
   frequency: Recurring
   next_date: TBD
-  website: ''
+  website: https://GoldCoastCoinClub.com
   organizer: ''
   notes: ''
 - id: the-villages-leesburg-coin-show
@@ -532,10 +532,10 @@
   state_name: Florida
   city: Plantation
   city_slug: plantation-fl
-  venue: ''
+  venue: 12050 W Sunrise Blvd, Plantation, FL 33323
   frequency: Monthly
   next_date: TBD
-  website: ''
+  website: https://GoldCoastCoinClub.com
   organizer: ''
   notes: ''
 - id: fort-lauderdale-coin-club-show
@@ -568,7 +568,7 @@
   state_name: Florida
   city: Tampa
   city_slug: tampa-fl
-  venue: ''
+  venue: 13336 N Central Ave, Tampa, FL
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -580,10 +580,10 @@
   state_name: Florida
   city: West Palm Beach
   city_slug: west-palm-beach-fl
-  venue: ''
+  venue: 4725 Lake Worth Rd, Greenacres, FL 33463
   frequency: Recurring
   next_date: TBD
-  website: ''
+  website: http://pbcc.anaclubs.org/
   organizer: ''
   notes: ''
 - id: the-villageswildwood-april-292026
@@ -616,7 +616,7 @@
   state_name: Georgia
   city: Carrollton
   city_slug: carrollton-ga
-  venue: ''
+  venue: 1201 Newnan Rd, Carrollton, GA 30116
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -700,7 +700,7 @@
   state_name: Idaho
   city: Garden City
   city_slug: garden-city-id
-  venue: ''
+  venue: 2900 W Chinden Blvd, Garden City, ID
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -739,7 +739,7 @@
   venue: ''
   frequency: Recurring
   next_date: TBD
-  website: ''
+  website: https://www.MetroEastCoinCurrencyClub.com
   organizer: ''
   notes: ''
 - id: chicago-coin-expo
@@ -788,6 +788,18 @@
   frequency: Monthly (1st Sunday)
   next_date: December 7, 2025
   website: https://www.coinshows-usa.com/Illinois
+  organizer: ''
+  notes: ''
+- id: peotone-coin-currency-show
+  name: Peotone Coin & Currency Show
+  state: IL
+  state_name: Illinois
+  city: Peotone
+  city_slug: peotone-il
+  venue: ''
+  frequency: Recurring
+  next_date: TBD
+  website: ''
   organizer: ''
   notes: ''
 - id: csns-convention
@@ -883,7 +895,7 @@
   venue: ''
   frequency: Recurring
   next_date: TBD
-  website: ''
+  website: http://lafayettecoinclub.tripod.com
   organizer: ''
   notes: ''
 - id: indiana-state-coin-show-nov-20th-21st-2026
@@ -1048,7 +1060,7 @@
   state_name: Maryland
   city: Timonium
   city_slug: timonium-md
-  venue: ''
+  venue: 2200 York Road, Timonium, MD 21093
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1180,10 +1192,10 @@
   state_name: Minnesota
   city: Maple Grove
   city_slug: maple-grove-mn
-  venue: ''
+  venue: 9655 Grove Circle North, Maple Grove, MN
   frequency: Recurring
   next_date: TBD
-  website: ''
+  website: https://antiquecoinsmn.com
   organizer: ''
   notes: ''
 - id: south-st-paul-coin-show
@@ -1348,7 +1360,7 @@
   state_name: North Carolina
   city: Morganton
   city_slug: morganton-nc
-  venue: ''
+  venue: 300 Collett St, Morganton, NC
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1552,7 +1564,7 @@
   state_name: New York
   city: Canandaigua
   city_slug: canandaigua-ny
-  venue: ''
+  venue: 454 N. Main Street, Canandaigua, NY 14424
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1636,7 +1648,7 @@
   state_name: Ohio
   city: Broadview Heights
   city_slug: broadview-heights-oh
-  venue: ''
+  venue: 5025 Mill Rd, Broadview Heights, OH
   frequency: Monthly
   next_date: TBD
   website: ''
@@ -1648,7 +1660,7 @@
   state_name: Ohio
   city: Broadview Heights
   city_slug: broadview-heights-oh
-  venue: ''
+  venue: 5025 Mill Rd, Broadview Heights, OH
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1744,7 +1756,7 @@
   state_name: Ohio
   city: Westlake
   city_slug: westlake-oh
-  venue: ''
+  venue: 24350 Center Ridge Rd, Westlake, OH 44145
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1780,7 +1792,7 @@
   state_name: Oklahoma
   city: Norman
   city_slug: norman-ok
-  venue: ''
+  venue: 615 E Robinson St, Norman, OK 73071
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1840,7 +1852,7 @@
   state_name: Pennsylvania
   city: Langhorne
   city_slug: langhorne-pa
-  venue: ''
+  venue: 400 N. Oxford Valley Rd, Langhorne, PA
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1852,7 +1864,7 @@
   state_name: Pennsylvania
   city: Langhorne
   city_slug: langhorne-pa
-  venue: ''
+  venue: 400 N. Oxford Valley Rd, Langhorne, PA
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1864,7 +1876,7 @@
   state_name: Pennsylvania
   city: Langhorne
   city_slug: langhorne-pa
-  venue: ''
+  venue: 400 N. Oxford Valley Rd, Langhorne, PA
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1876,7 +1888,7 @@
   state_name: Pennsylvania
   city: Langhorne
   city_slug: langhorne-pa
-  venue: ''
+  venue: 400 N. Oxford Valley Rd, Langhorne, PA
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1888,7 +1900,7 @@
   state_name: Pennsylvania
   city: Langhorne
   city_slug: langhorne-pa
-  venue: ''
+  venue: 400 N. Oxford Valley Rd, Langhorne, PA
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1900,7 +1912,7 @@
   state_name: Pennsylvania
   city: Langhorne
   city_slug: langhorne-pa
-  venue: ''
+  venue: 400 N. Oxford Valley Rd, Langhorne, PA
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1912,7 +1924,7 @@
   state_name: Pennsylvania
   city: Langhorne
   city_slug: langhorne-pa
-  venue: ''
+  venue: 400 N. Oxford Valley Rd, Langhorne, PA
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1924,7 +1936,7 @@
   state_name: Pennsylvania
   city: Langhorne
   city_slug: langhorne-pa
-  venue: ''
+  venue: 400 N. Oxford Valley Rd, Langhorne, PA
   frequency: Recurring
   next_date: TBD
   website: ''
@@ -1984,7 +1996,7 @@
   state_name: Pennsylvania
   city: Telford
   city_slug: telford-pa
-  venue: ''
+  venue: 508 Harleysville Pike Unit A, Telford, PA 18969
   frequency: Monthly
   next_date: TBD
   website: ''
@@ -1999,7 +2011,7 @@
   venue: ''
   frequency: Monthly
   next_date: TBD
-  website: ''
+  website: https://www.buxmontcoinshows.com
   organizer: ''
   notes: ''
 - id: tri-state-monthly-coin-show
@@ -2068,10 +2080,10 @@
   state_name: South Carolina
   city: Sumter Coin Club
   city_slug: sumter-coin-club-sc
-  venue: ''
+  venue: 2320 Four Bridges Road, Sumter, SC
   frequency: Annual
   next_date: TBD
-  website: ''
+  website: https://www.sumtercoinclub.org
   organizer: ''
   notes: ''
 - id: ama-fall-coin-stamp-show
@@ -2155,7 +2167,7 @@
   venue: ''
   frequency: Recurring
   next_date: TBD
-  website: ''
+  website: https://www.TexasNumismatics.org
   organizer: ''
   notes: ''
 - id: cowtown-coin-show

--- a/cities/peotone-il.md
+++ b/cities/peotone-il.md
@@ -1,0 +1,15 @@
+---
+layout: city
+title: "Coin Shows in Peotone, Illinois — 2026-2027"
+seo_title: "Coin Shows in Peotone, Illinois — 2026-2027 Schedule | Coin Show Near Me"
+seo_description: "Find 1 coin show in Peotone, Illinois. Dates, venues, and details for upcoming coin shows and numismatic events in Peotone."
+permalink: /cities/peotone-il/
+city_slug: "peotone-il"
+city_name: "Peotone"
+state_name: "Illinois"
+state_slug: "illinois"
+breadcrumb_parent: "Illinois"
+breadcrumb_parent_url: "/states/illinois/"
+breadcrumb_current: "Peotone"
+nav_exclude: true
+---

--- a/shows/baltimore-stamp-and-coin-show.md
+++ b/shows/baltimore-stamp-and-coin-show.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Baltimore Stamp and Coin Show — Timonium, Maryland Coin Show"
 seo_title: "Baltimore Stamp and Coin Show — Timonium, Maryland | Coin Show Near Me"
-seo_description: "Baltimore Stamp and Coin Show in Timonium, Maryland. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Baltimore Stamp and Coin Show in Timonium, Maryland. Recurring coin show at 2200 York Road, Timonium, MD 21093. Get dates, venue details, and more."
 permalink: /shows/baltimore-stamp-and-coin-show/
 show_id: "baltimore-stamp-and-coin-show"
 breadcrumb_parent: "Maryland"

--- a/shows/canandaigua-coin-show.md
+++ b/shows/canandaigua-coin-show.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Canandaigua Coin Show — Canandaigua, New York Coin Show"
 seo_title: "Canandaigua Coin Show — Canandaigua, New York | Coin Show Near Me"
-seo_description: "Canandaigua Coin Show in Canandaigua, New York. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Canandaigua Coin Show in Canandaigua, New York. Recurring coin show at 454 N. Main Street, Canandaigua, NY 14424. Get dates, venue details, and more."
 permalink: /shows/canandaigua-coin-show/
 show_id: "canandaigua-coin-show"
 breadcrumb_parent: "New York"

--- a/shows/cleveland-coin-expo-2nd-saturdays-monthly-9am-2pm.md
+++ b/shows/cleveland-coin-expo-2nd-saturdays-monthly-9am-2pm.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Cleveland Coin Expo - 2nd Saturdays Monthly - 9AM-2PM — Broadview Heights, Ohio Coin Show"
 seo_title: "Cleveland Coin Expo - 2nd Saturdays Monthly - 9AM-2PM — Broadview Heights, Ohio | Coin Show Near Me"
-seo_description: "Cleveland Coin Expo - 2nd Saturdays Monthly - 9AM-2PM in Broadview Heights, Ohio. Monthly coin show at . Get dates, venue details, and more."
+seo_description: "Cleveland Coin Expo - 2nd Saturdays Monthly - 9AM-2PM in Broadview Heights, Ohio. Monthly coin show at 5025 Mill Rd, Broadview Heights, OH. Get dates, venue details, and more."
 permalink: /shows/cleveland-coin-expo-2nd-saturdays-monthly-9am-2pm/
 show_id: "cleveland-coin-expo-2nd-saturdays-monthly-9am-2pm"
 breadcrumb_parent: "Ohio"

--- a/shows/cleveland-coin-expo-meets-2nd-saturday-of-each-month.md
+++ b/shows/cleveland-coin-expo-meets-2nd-saturday-of-each-month.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Cleveland Coin Expo - Meets 2nd Saturday of Each Month — Broadview Heights, Ohio Coin Show"
 seo_title: "Cleveland Coin Expo - Meets 2nd Saturday of Each Month — Broadview Heights, Ohio | Coin Show Near Me"
-seo_description: "Cleveland Coin Expo - Meets 2nd Saturday of Each Month in Broadview Heights, Ohio. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Cleveland Coin Expo - Meets 2nd Saturday of Each Month in Broadview Heights, Ohio. Recurring coin show at 5025 Mill Rd, Broadview Heights, OH. Get dates, venue details, and more."
 permalink: /shows/cleveland-coin-expo-meets-2nd-saturday-of-each-month/
 show_id: "cleveland-coin-expo-meets-2nd-saturday-of-each-month"
 breadcrumb_parent: "Ohio"

--- a/shows/coinacopia-tampas-coin-show.md
+++ b/shows/coinacopia-tampas-coin-show.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Coinacopia Tampa's Coin Show — Tampa, Florida Coin Show"
 seo_title: "Coinacopia Tampa's Coin Show — Tampa, Florida | Coin Show Near Me"
-seo_description: "Coinacopia Tampa's Coin Show in Tampa, Florida. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Coinacopia Tampa's Coin Show in Tampa, Florida. Recurring coin show at 13336 N Central Ave, Tampa, FL. Get dates, venue details, and more."
 permalink: /shows/coinacopia-tampas-coin-show/
 show_id: "coinacopia-tampas-coin-show"
 breadcrumb_parent: "Florida"

--- a/shows/cupertino-coin-club-annual-coin-show.md
+++ b/shows/cupertino-coin-club-annual-coin-show.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Cupertino Coin Club Annual Coin Show — Cupertino, California Coin Show"
 seo_title: "Cupertino Coin Club Annual Coin Show — Cupertino, California | Coin Show Near Me"
-seo_description: "Cupertino Coin Club Annual Coin Show in Cupertino, California. Annual coin show at . Get dates, venue details, and more."
+seo_description: "Cupertino Coin Club Annual Coin Show in Cupertino, California. Annual coin show at 10110 N DeAnza Blvd, Cupertino, CA. Get dates, venue details, and more."
 permalink: /shows/cupertino-coin-club-annual-coin-show/
 show_id: "cupertino-coin-club-annual-coin-show"
 breadcrumb_parent: "California"

--- a/shows/fort-lauderdale-coin-show-3rd-sundays-monthly-9am-3pm.md
+++ b/shows/fort-lauderdale-coin-show-3rd-sundays-monthly-9am-3pm.md
@@ -2,7 +2,7 @@
 layout: show
 title: "FORT LAUDERDALE COIN SHOW - 3rd Sundays Monthly - 9AM-3PM — Plantation, Florida Coin Show"
 seo_title: "FORT LAUDERDALE COIN SHOW - 3rd Sundays Monthly - 9AM-3PM — Plantation, Florida | Coin Show Near Me"
-seo_description: "FORT LAUDERDALE COIN SHOW - 3rd Sundays Monthly - 9AM-3PM in Plantation, Florida. Monthly coin show at . Get dates, venue details, and more."
+seo_description: "FORT LAUDERDALE COIN SHOW - 3rd Sundays Monthly - 9AM-3PM in Plantation, Florida. Monthly coin show at 12050 W Sunrise Blvd, Plantation, FL 33323. Get dates, venue details, and more."
 permalink: /shows/fort-lauderdale-coin-show-3rd-sundays-monthly-9am-3pm/
 show_id: "fort-lauderdale-coin-show-3rd-sundays-monthly-9am-3pm"
 breadcrumb_parent: "Florida"

--- a/shows/montco-coin-show-meets-every-2nd-sunday-each-month.md
+++ b/shows/montco-coin-show-meets-every-2nd-sunday-each-month.md
@@ -2,7 +2,7 @@
 layout: show
 title: "MontCo Coin Show - Meets Every 2nd Sunday each Month — Telford, Pennsylvania Coin Show"
 seo_title: "MontCo Coin Show - Meets Every 2nd Sunday each Month — Telford, Pennsylvania | Coin Show Near Me"
-seo_description: "MontCo Coin Show - Meets Every 2nd Sunday each Month in Telford, Pennsylvania. Monthly coin show at . Get dates, venue details, and more."
+seo_description: "MontCo Coin Show - Meets Every 2nd Sunday each Month in Telford, Pennsylvania. Monthly coin show at 508 Harleysville Pike Unit A, Telford, PA 18969. Get dates, venue details, and more."
 permalink: /shows/montco-coin-show-meets-every-2nd-sunday-each-month/
 show_id: "montco-coin-show-meets-every-2nd-sunday-each-month"
 breadcrumb_parent: "Pennsylvania"

--- a/shows/morganton-coin-club-show-saturday-may-30th-2026.md
+++ b/shows/morganton-coin-club-show-saturday-may-30th-2026.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Morganton Coin Club Show - Saturday, May 30th, 2026 — Morganton, North Carolina Coin Show"
 seo_title: "Morganton Coin Club Show - Saturday, May 30th, 2026 — Morganton, North Carolina | Coin Show Near Me"
-seo_description: "Morganton Coin Club Show - Saturday, May 30th, 2026 in Morganton, North Carolina. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Morganton Coin Club Show - Saturday, May 30th, 2026 in Morganton, North Carolina. Recurring coin show at 300 Collett St, Morganton, NC. Get dates, venue details, and more."
 permalink: /shows/morganton-coin-club-show-saturday-may-30th-2026/
 show_id: "morganton-coin-club-show-saturday-may-30th-2026"
 breadcrumb_parent: "North Carolina"

--- a/shows/north-metro-coin-show.md
+++ b/shows/north-metro-coin-show.md
@@ -2,7 +2,7 @@
 layout: show
 title: "North Metro Coin Show — Maple Grove, Minnesota Coin Show"
 seo_title: "North Metro Coin Show — Maple Grove, Minnesota | Coin Show Near Me"
-seo_description: "North Metro Coin Show in Maple Grove, Minnesota. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "North Metro Coin Show in Maple Grove, Minnesota. Recurring coin show at 9655 Grove Circle North, Maple Grove, MN. Get dates, venue details, and more."
 permalink: /shows/north-metro-coin-show/
 show_id: "north-metro-coin-show"
 breadcrumb_parent: "Minnesota"

--- a/shows/palm-beach-coin-show.md
+++ b/shows/palm-beach-coin-show.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Palm Beach Coin Show — West Palm Beach, Florida Coin Show"
 seo_title: "Palm Beach Coin Show — West Palm Beach, Florida | Coin Show Near Me"
-seo_description: "Palm Beach Coin Show in West Palm Beach, Florida. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Palm Beach Coin Show in West Palm Beach, Florida. Recurring coin show at 4725 Lake Worth Rd, Greenacres, FL 33463. Get dates, venue details, and more."
 permalink: /shows/palm-beach-coin-show/
 show_id: "palm-beach-coin-show"
 breadcrumb_parent: "Florida"

--- a/shows/peotone-coin-currency-show.md
+++ b/shows/peotone-coin-currency-show.md
@@ -1,0 +1,12 @@
+---
+layout: show
+title: "Peotone Coin & Currency Show — Peotone, Illinois Coin Show"
+seo_title: "Peotone Coin & Currency Show — Peotone, Illinois | Coin Show Near Me"
+seo_description: "Peotone Coin & Currency Show in Peotone, Illinois. Recurring coin show at . Get dates, venue details, and more."
+permalink: /shows/peotone-coin-currency-show/
+show_id: "peotone-coin-currency-show"
+breadcrumb_parent: "Illinois"
+breadcrumb_parent_url: "/states/illinois/"
+breadcrumb_current: "Peotone Coin & Currency Show"
+nav_exclude: true
+---

--- a/shows/sacramento-valley-coin-club.md
+++ b/shows/sacramento-valley-coin-club.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Sacramento Valley Coin Club — Sacramento, California Coin Show"
 seo_title: "Sacramento Valley Coin Club — Sacramento, California | Coin Show Near Me"
-seo_description: "Sacramento Valley Coin Club in Sacramento, California. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Sacramento Valley Coin Club in Sacramento, California. Recurring coin show at 3410 Westover Street, Sacramento, CA. Get dates, venue details, and more."
 permalink: /shows/sacramento-valley-coin-club/
 show_id: "sacramento-valley-coin-club"
 breadcrumb_parent: "California"

--- a/shows/santa-clara-coin-show.md
+++ b/shows/santa-clara-coin-show.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Santa Clara Coin Show — Santa Clara, California Coin Show"
 seo_title: "Santa Clara Coin Show — Santa Clara, California | Coin Show Near Me"
-seo_description: "Santa Clara Coin Show in Santa Clara, California. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Santa Clara Coin Show in Santa Clara, California. Recurring coin show at American Legion Post 419, 958 Homestead Road, Santa Clara, CA. Get dates, venue details, and more."
 permalink: /shows/santa-clara-coin-show/
 show_id: "santa-clara-coin-show"
 breadcrumb_parent: "California"

--- a/shows/southern-idaho-coin-club-coin-show.md
+++ b/shows/southern-idaho-coin-club-coin-show.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Southern Idaho Coin Club - Coin Show — Garden City, Idaho Coin Show"
 seo_title: "Southern Idaho Coin Club - Coin Show — Garden City, Idaho | Coin Show Near Me"
-seo_description: "Southern Idaho Coin Club - Coin Show in Garden City, Idaho. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Southern Idaho Coin Club - Coin Show in Garden City, Idaho. Recurring coin show at 2900 W Chinden Blvd, Garden City, ID. Get dates, venue details, and more."
 permalink: /shows/southern-idaho-coin-club-coin-show/
 show_id: "southern-idaho-coin-club-coin-show"
 breadcrumb_parent: "Idaho"

--- a/shows/sumter-2026-annual-coin-and-currency-show.md
+++ b/shows/sumter-2026-annual-coin-and-currency-show.md
@@ -2,7 +2,7 @@
 layout: show
 title: "SUMTER 2026 ANNUAL COIN AND CURRENCY SHOW — Sumter Coin Club, South Carolina Coin Show"
 seo_title: "SUMTER 2026 ANNUAL COIN AND CURRENCY SHOW — Sumter Coin Club, South Carolina | Coin Show Near Me"
-seo_description: "SUMTER 2026 ANNUAL COIN AND CURRENCY SHOW in Sumter Coin Club, South Carolina. Annual coin show at . Get dates, venue details, and more."
+seo_description: "SUMTER 2026 ANNUAL COIN AND CURRENCY SHOW in Sumter Coin Club, South Carolina. Annual coin show at 2320 Four Bridges Road, Sumter, SC. Get dates, venue details, and more."
 permalink: /shows/sumter-2026-annual-coin-and-currency-show/
 show_id: "sumter-2026-annual-coin-and-currency-show"
 breadcrumb_parent: "South Carolina"

--- a/shows/the-ohio-coin-and-collectibles-show.md
+++ b/shows/the-ohio-coin-and-collectibles-show.md
@@ -2,7 +2,7 @@
 layout: show
 title: "The Ohio Coin and Collectibles Show — Westlake, Ohio Coin Show"
 seo_title: "The Ohio Coin and Collectibles Show — Westlake, Ohio | Coin Show Near Me"
-seo_description: "The Ohio Coin and Collectibles Show in Westlake, Ohio. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "The Ohio Coin and Collectibles Show in Westlake, Ohio. Recurring coin show at 24350 Center Ridge Rd, Westlake, OH 44145. Get dates, venue details, and more."
 permalink: /shows/the-ohio-coin-and-collectibles-show/
 show_id: "the-ohio-coin-and-collectibles-show"
 breadcrumb_parent: "Ohio"

--- a/shows/tri-state-coin-stamp-and-paper-money-show-august-16th-2026.md
+++ b/shows/tri-state-coin-stamp-and-paper-money-show-august-16th-2026.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Tri-State Coin, Stamp and Paper Money Show AUGUST 16th, 2026 — Langhorne, Pennsylvania Coin Show"
 seo_title: "Tri-State Coin, Stamp and Paper Money Show AUGUST 16th, 2026 — Langhorne, Pennsylvania | Coin Show Near Me"
-seo_description: "Tri-State Coin, Stamp and Paper Money Show AUGUST 16th, 2026 in Langhorne, Pennsylvania. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Tri-State Coin, Stamp and Paper Money Show AUGUST 16th, 2026 in Langhorne, Pennsylvania. Recurring coin show at 400 N. Oxford Valley Rd, Langhorne, PA. Get dates, venue details, and more."
 permalink: /shows/tri-state-coin-stamp-and-paper-money-show-august-16th-2026/
 show_id: "tri-state-coin-stamp-and-paper-money-show-august-16th-2026"
 breadcrumb_parent: "Pennsylvania"

--- a/shows/tri-state-coin-stamp-and-paper-money-show-december-20th-2026.md
+++ b/shows/tri-state-coin-stamp-and-paper-money-show-december-20th-2026.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Tri-State Coin, Stamp and Paper Money Show DECEMBER 20th, 2026 — Langhorne, Pennsylvania Coin Show"
 seo_title: "Tri-State Coin, Stamp and Paper Money Show DECEMBER 20th, 2026 — Langhorne, Pennsylvania | Coin Show Near Me"
-seo_description: "Tri-State Coin, Stamp and Paper Money Show DECEMBER 20th, 2026 in Langhorne, Pennsylvania. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Tri-State Coin, Stamp and Paper Money Show DECEMBER 20th, 2026 in Langhorne, Pennsylvania. Recurring coin show at 400 N. Oxford Valley Rd, Langhorne, PA. Get dates, venue details, and more."
 permalink: /shows/tri-state-coin-stamp-and-paper-money-show-december-20th-2026/
 show_id: "tri-state-coin-stamp-and-paper-money-show-december-20th-2026"
 breadcrumb_parent: "Pennsylvania"

--- a/shows/tri-state-coin-stamp-and-paper-money-show-july-19st-2026.md
+++ b/shows/tri-state-coin-stamp-and-paper-money-show-july-19st-2026.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Tri-State Coin, Stamp and Paper Money Show JUly 19st, 2026 — Langhorne, Pennsylvania Coin Show"
 seo_title: "Tri-State Coin, Stamp and Paper Money Show JUly 19st, 2026 — Langhorne, Pennsylvania | Coin Show Near Me"
-seo_description: "Tri-State Coin, Stamp and Paper Money Show JUly 19st, 2026 in Langhorne, Pennsylvania. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Tri-State Coin, Stamp and Paper Money Show JUly 19st, 2026 in Langhorne, Pennsylvania. Recurring coin show at 400 N. Oxford Valley Rd, Langhorne, PA. Get dates, venue details, and more."
 permalink: /shows/tri-state-coin-stamp-and-paper-money-show-july-19st-2026/
 show_id: "tri-state-coin-stamp-and-paper-money-show-july-19st-2026"
 breadcrumb_parent: "Pennsylvania"

--- a/shows/tri-state-coin-stamp-and-paper-money-show-june-21st-2026.md
+++ b/shows/tri-state-coin-stamp-and-paper-money-show-june-21st-2026.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Tri-State Coin, Stamp and Paper Money Show JUNE 21st, 2026 — Langhorne, Pennsylvania Coin Show"
 seo_title: "Tri-State Coin, Stamp and Paper Money Show JUNE 21st, 2026 — Langhorne, Pennsylvania | Coin Show Near Me"
-seo_description: "Tri-State Coin, Stamp and Paper Money Show JUNE 21st, 2026 in Langhorne, Pennsylvania. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Tri-State Coin, Stamp and Paper Money Show JUNE 21st, 2026 in Langhorne, Pennsylvania. Recurring coin show at 400 N. Oxford Valley Rd, Langhorne, PA. Get dates, venue details, and more."
 permalink: /shows/tri-state-coin-stamp-and-paper-money-show-june-21st-2026/
 show_id: "tri-state-coin-stamp-and-paper-money-show-june-21st-2026"
 breadcrumb_parent: "Pennsylvania"

--- a/shows/tri-state-coin-stamp-and-paper-money-show-may-17th-2026.md
+++ b/shows/tri-state-coin-stamp-and-paper-money-show-may-17th-2026.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Tri-State Coin. Stamp and Paper Money Show MAY 17th, 2026 — Langhorne, Pennsylvania Coin Show"
 seo_title: "Tri-State Coin. Stamp and Paper Money Show MAY 17th, 2026 — Langhorne, Pennsylvania | Coin Show Near Me"
-seo_description: "Tri-State Coin. Stamp and Paper Money Show MAY 17th, 2026 in Langhorne, Pennsylvania. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Tri-State Coin. Stamp and Paper Money Show MAY 17th, 2026 in Langhorne, Pennsylvania. Recurring coin show at 400 N. Oxford Valley Rd, Langhorne, PA. Get dates, venue details, and more."
 permalink: /shows/tri-state-coin-stamp-and-paper-money-show-may-17th-2026/
 show_id: "tri-state-coin-stamp-and-paper-money-show-may-17th-2026"
 breadcrumb_parent: "Pennsylvania"

--- a/shows/tri-state-coin-stamp-and-paper-money-show-november-15th-2026.md
+++ b/shows/tri-state-coin-stamp-and-paper-money-show-november-15th-2026.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Tri-State Coin, Stamp and Paper Money Show NOVEMBER 15th, 2026 — Langhorne, Pennsylvania Coin Show"
 seo_title: "Tri-State Coin, Stamp and Paper Money Show NOVEMBER 15th, 2026 — Langhorne, Pennsylvania | Coin Show Near Me"
-seo_description: "Tri-State Coin, Stamp and Paper Money Show NOVEMBER 15th, 2026 in Langhorne, Pennsylvania. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Tri-State Coin, Stamp and Paper Money Show NOVEMBER 15th, 2026 in Langhorne, Pennsylvania. Recurring coin show at 400 N. Oxford Valley Rd, Langhorne, PA. Get dates, venue details, and more."
 permalink: /shows/tri-state-coin-stamp-and-paper-money-show-november-15th-2026/
 show_id: "tri-state-coin-stamp-and-paper-money-show-november-15th-2026"
 breadcrumb_parent: "Pennsylvania"

--- a/shows/tri-state-coin-stamp-and-paper-money-show-october-18th-2026.md
+++ b/shows/tri-state-coin-stamp-and-paper-money-show-october-18th-2026.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Tri-State Coin, Stamp and Paper Money Show OCTOBER 18th, 2026 — Langhorne, Pennsylvania Coin Show"
 seo_title: "Tri-State Coin, Stamp and Paper Money Show OCTOBER 18th, 2026 — Langhorne, Pennsylvania | Coin Show Near Me"
-seo_description: "Tri-State Coin, Stamp and Paper Money Show OCTOBER 18th, 2026 in Langhorne, Pennsylvania. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Tri-State Coin, Stamp and Paper Money Show OCTOBER 18th, 2026 in Langhorne, Pennsylvania. Recurring coin show at 400 N. Oxford Valley Rd, Langhorne, PA. Get dates, venue details, and more."
 permalink: /shows/tri-state-coin-stamp-and-paper-money-show-october-18th-2026/
 show_id: "tri-state-coin-stamp-and-paper-money-show-october-18th-2026"
 breadcrumb_parent: "Pennsylvania"

--- a/shows/tri-state-coin-stamp-and-paper-money-show-september-20th-2026.md
+++ b/shows/tri-state-coin-stamp-and-paper-money-show-september-20th-2026.md
@@ -2,7 +2,7 @@
 layout: show
 title: "Tri-State Coin, Stamp and Paper Money Show SEPTEMBER 20th, 2026 — Langhorne, Pennsylvania Coin Show"
 seo_title: "Tri-State Coin, Stamp and Paper Money Show SEPTEMBER 20th, 2026 — Langhorne, Pennsylvania | Coin Show Near Me"
-seo_description: "Tri-State Coin, Stamp and Paper Money Show SEPTEMBER 20th, 2026 in Langhorne, Pennsylvania. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "Tri-State Coin, Stamp and Paper Money Show SEPTEMBER 20th, 2026 in Langhorne, Pennsylvania. Recurring coin show at 400 N. Oxford Valley Rd, Langhorne, PA. Get dates, venue details, and more."
 permalink: /shows/tri-state-coin-stamp-and-paper-money-show-september-20th-2026/
 show_id: "tri-state-coin-stamp-and-paper-money-show-september-20th-2026"
 breadcrumb_parent: "Pennsylvania"

--- a/shows/were-back-norman-ok-coin-show-friday-512026-to-saturday-522026.md
+++ b/shows/were-back-norman-ok-coin-show-friday-512026-to-saturday-522026.md
@@ -2,7 +2,7 @@
 layout: show
 title: "WE'RE BACK! NORMAN, OK COIN SHOW - FRIDAY 5/1/2026 to SATURDAY 5/2/2026 — Norman, Oklahoma Coin Show"
 seo_title: "WE'RE BACK! NORMAN, OK COIN SHOW - FRIDAY 5/1/2026 to SATURDAY 5/2/2026 — Norman, Oklahoma | Coin Show Near Me"
-seo_description: "WE'RE BACK! NORMAN, OK COIN SHOW - FRIDAY 5/1/2026 to SATURDAY 5/2/2026 in Norman, Oklahoma. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "WE'RE BACK! NORMAN, OK COIN SHOW - FRIDAY 5/1/2026 to SATURDAY 5/2/2026 in Norman, Oklahoma. Recurring coin show at 615 E Robinson St, Norman, OK 73071. Get dates, venue details, and more."
 permalink: /shows/were-back-norman-ok-coin-show-friday-512026-to-saturday-522026/
 show_id: "were-back-norman-ok-coin-show-friday-512026-to-saturday-522026"
 breadcrumb_parent: "Oklahoma"

--- a/shows/west-georgia-coin-show.md
+++ b/shows/west-georgia-coin-show.md
@@ -2,7 +2,7 @@
 layout: show
 title: "West Georgia Coin Show — Carrollton, Georgia Coin Show"
 seo_title: "West Georgia Coin Show — Carrollton, Georgia | Coin Show Near Me"
-seo_description: "West Georgia Coin Show in Carrollton, Georgia. Recurring coin show at . Get dates, venue details, and more."
+seo_description: "West Georgia Coin Show in Carrollton, Georgia. Recurring coin show at 1201 Newnan Rd, Carrollton, GA 30116. Get dates, venue details, and more."
 permalink: /shows/west-georgia-coin-show/
 show_id: "west-georgia-coin-show"
 breadcrumb_parent: "Georgia"

--- a/states/illinois.md
+++ b/states/illinois.md
@@ -2,7 +2,7 @@
 layout: state
 title: "Coin Shows in Illinois — 2026-2027 Schedule"
 seo_title: "Coin Shows in Illinois — 2026-2027 Schedule & Directory | Coin Show Near Me"
-seo_description: "Find 8 coin shows in Illinois. Complete directory with dates, venues, and details for Illinois coin shows, expos, and numismatic events."
+seo_description: "Find 9 coin shows in Illinois. Complete directory with dates, venues, and details for Illinois coin shows, expos, and numismatic events."
 permalink: /states/illinois/
 state_abbrev: "IL"
 state_name: "Illinois"


### PR DESCRIPTION
## Summary

Fresh scrape of CoinZip (154 unique shows from 296 listings) and CoinShows-USA (30 shows). Extracted venue addresses and website URLs from CoinZip detail page metadata.

- **Venues**: 127 → 153 shows with venue addresses (+26)
- **Websites**: 127 → 138 shows with website links (+11)
- **New show**: Peotone Coin & Currency Show (Peotone, IL)
- **Pages**: 407 → 409 (new city + show pages generated)

All venue data was manually reviewed — cross-state contamination and garbage text filtered out.