### PR TITLE
Add GSC verification for coinshownearme.com

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,4 +1,5 @@
 <meta name="google-site-verification" content="ZW60JDUpZFD9rhZv8KgiklQ65RSr5jyyxku3686lHbo">
+<meta name="google-site-verification" content="DqU8VGv1svEy5GVzQoi1vn1My7ubNJgeHdBQfokkNbk">
 {% include seo-meta.html %}
 
 <style>


### PR DESCRIPTION
Add Google Search Console verification meta tag for the coinshownearme.com URL prefix property. Keeps the old github.io verification tag alongside it.