### PR TITLE
fix: spot price ticker not loading

### DIFF
--- a/index.md
+++ b/index.md
@@ -176,7 +176,7 @@ if (form) {
 
 <script>
 // Load spot prices from pre-fetched JSON (updated hourly by GitHub Actions)
-(function() {
+document.addEventListener('DOMContentLoaded', function() {
   function formatPrice(price) {
     if (price == null) return '--';
     return '$' + price.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -192,8 +192,12 @@ if (form) {
     var days = Math.round(hrs / 24);
     return days + ' day' + (days > 1 ? 's' : '') + ' ago';
   }
-  fetch('/assets/data/spot-prices.json')
-    .then(function(r) { return r.json(); })
+  var jsonUrl = window.location.origin + '/assets/data/spot-prices.json';
+  fetch(jsonUrl)
+    .then(function(r) {
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      return r.json();
+    })
     .then(function(data) {
       document.getElementById('spot-gold-price').textContent = formatPrice(data.gold);
       document.getElementById('spot-silver-price').textContent = formatPrice(data.silver);
@@ -201,13 +205,13 @@ if (form) {
       document.getElementById('spot-palladium-price').textContent = formatPrice(data.palladium);
       var updated = data.updated_at ? 'Updated ' + timeAgo(data.updated_at) + ' · Spot prices per troy oz' : 'Spot prices per troy oz';
       document.getElementById('spot-ticker-updated').textContent = updated;
-      // Store prices globally for the melt calculator link
       window.SPOT_PRICES = data;
     })
-    .catch(function() {
+    .catch(function(err) {
+      console.error('Spot prices failed:', err);
       document.getElementById('spot-ticker-updated').textContent = 'Spot prices temporarily unavailable';
     });
-})();
+});
 </script>
 
 <script type="application/ld+json">


### PR DESCRIPTION
## Summary

Spot price ticker permanently shows "Loading spot prices..." — prices never populate despite the JSON endpoint being live and returning valid data.

## Changes

- Wrap fetch in `DOMContentLoaded` — the just-the-docs theme may defer inline script execution in markdown content, causing the IIFE to fire before DOM elements are queryable
- Use absolute URL (`window.location.origin + path`) instead of root-relative `/assets/data/spot-prices.json`
- Add HTTP status check (`r.ok`) before parsing JSON
- Add `console.error` logging in catch handler for future debugging

## Verification

After merge and GitHub Pages deploy (~2 min), visit https://coinshownearme.com/ — ticker should show current gold/silver/platinum/palladium prices instead of "Loading spot prices..."

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.21 with claude-opus-4-6 spent 35m and 13,510 tokens on this with the user in an interactive session.
