### PR TITLE
fix: exclude CHANGELOG from site, bump to v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG — Coin Shows Near Me (coinshownearme.com)
 
+## Apr 26, 2026
+- v0.6.0: Excluded CHANGELOG from public site (was appearing in nav)
+- Fixed spot price ticker not loading (DOMContentLoaded + absolute URL)
+- v0.5.4: Reverted hero map, restored clean homepage
+
 ## Apr 17, 2026
 - Removed 51 competitor directory links from show website fields
 - Added GA4 + Microsoft Clarity analytics tracking

--- a/_config.yml
+++ b/_config.yml
@@ -39,4 +39,5 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - TODO.md
+  - CHANGELOG.md
   - LICENSE

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,1 +1,1 @@
-<div class="site-version">v0.5.4</div>
+<div class="site-version">v0.6.0</div>


### PR DESCRIPTION
## Summary

- Exclude `CHANGELOG.md` from Jekyll build — it was rendering as a public page and appearing in the site navigation
- Bump version from v0.5.4 to v0.6.0
- Update CHANGELOG with recent entries (spot price fix, hero map revert)

No blog posts found in the repo — confirmed clean.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-6 spent 3d 14h and 17,549 tokens on this with the user in an interactive session.
