### PR TITLE
chore: bump version to v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG — Coin Shows Near Me (coinshownearme.com)
 
+## Apr 29, 2026
+- v0.7.3: Dealer portal inquiry form (Formspree) — name, email, show, interest dropdown, description
+- v0.7.2: Construction banner + nav bar sticky together on scroll, filter bar offset adjusted
+- v0.7.1: Added construction disclaimer banner + dealer portal CTA section
+
 ## Apr 28, 2026
 - v0.7.0: Full homepage redesign — Nomads.com-inspired directory layout
   - Custom full-width homepage (no more just-the-docs sidebar on homepage)

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,1 +1,1 @@
-<div class="site-version">v0.7.0</div>
+<div class="site-version">v0.7.3</div>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -1138,7 +1138,7 @@ a:hover { color: var(--gold-light); }
       <a href="/legal/">Legal</a>
     </div>
     <div class="footer-copy">&copy; {{ site.time | date: '%Y' }} Coin Show Near Me &mdash; All rights reserved.</div>
-    <div class="footer-version">v0.7.0</div>
+    <div class="footer-version">v0.7.3</div>
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary

Catch-up version bump from v0.7.0 to v0.7.3. Three releases shipped without version increments.

## Version History

- **v0.7.1** — Construction disclaimer banner + dealer portal CTA section
- **v0.7.2** — Sticky construction banner (pinned with nav on scroll) + filter bar offset fix
- **v0.7.3** — Dealer portal inquiry form (Formspree) replacing static CTA

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 6d 4h and 63,871 tokens on this with the user in an interactive session.
