### PR TITLE
feat: form updates — quote subject fix + dealer registration toggle (v0.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG — Coin Shows Near Me (coinshownearme.com)
 
 ## Apr 29, 2026
+- v0.7.4: Reworked forms — quote form subject now "Attendee Wants a Quote", added dealer checkbox toggle in Stay in the Loop section that reveals a dealer registration form (name, business, email, phone, website, specialty, shows attended)
 - v0.7.3: Dealer portal inquiry form (Formspree) — name, email, show, interest dropdown, description
 - v0.7.2: Construction banner + nav bar sticky together on scroll, filter bar offset adjusted
 - v0.7.1: Added construction disclaimer banner + dealer portal CTA section

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,1 +1,1 @@
-<div class="site-version">v0.7.3</div>
+<div class="site-version">v0.7.4</div>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -767,6 +767,69 @@ a:hover { color: var(--gold-light); }
   margin-top: 1rem;
   font-size: 0.9rem;
 }
+.dealer-toggle {
+  margin: 1.5rem 0 0;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(255,255,255,0.1);
+}
+.dealer-toggle label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  cursor: pointer;
+  color: #94a3b8;
+  font-size: 0.9rem;
+  user-select: none;
+}
+.dealer-toggle input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: var(--gold);
+  cursor: pointer;
+}
+.dealer-signup-form {
+  display: none;
+  margin-top: 1.25rem;
+  text-align: left;
+}
+.dealer-signup-form.visible { display: block; }
+.dealer-signup-form h3 {
+  color: var(--gold-light);
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  text-align: center;
+}
+.dealer-signup-form p {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+.dealer-signup-form .cta-form { flex-direction: column; }
+.dealer-signup-form .cta-form .form-row-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+  width: 100%;
+}
+.dealer-signup-form .cta-form select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  background: rgba(255,255,255,0.1);
+  color: #94a3b8;
+  outline: none;
+  font-family: inherit;
+}
+.dealer-signup-form .cta-form select option { background: var(--navy); color: #fff; }
+.dealer-signup-form .cta-form select:focus { border-color: var(--gold-light); }
+@media (max-width: 768px) {
+  .dealer-signup-form .cta-form .form-row-2 { grid-template-columns: 1fr; }
+}
 
 /* === Footer === */
 .site-footer {
@@ -1086,7 +1149,7 @@ a:hover { color: var(--gold-light); }
     </div>
     <div>
       <form class="dealer-form" id="dealer-form" action="https://formspree.io/f/mykleozw" method="POST">
-        <input type="hidden" name="_subject" value="Coin Show Near Me — Dealer Portal Inquiry">
+        <input type="hidden" name="_subject" value="Coin Show Near Me — Attendee Wants a Quote">
         <div class="form-row">
           <input type="text" name="name" placeholder="Your name" required>
           <input type="email" name="email" placeholder="Email address" required>
@@ -1097,7 +1160,6 @@ a:hover { color: var(--gold-light); }
           <option value="sell">Sell coins or collection</option>
           <option value="appraisal">Get an appraisal</option>
           <option value="buy">Buy specific coins</option>
-          <option value="dealer">I'm a dealer — list me</option>
           <option value="other">Other</option>
         </select>
         <textarea name="message" placeholder="Describe what you have or what you're looking for..."></textarea>
@@ -1125,6 +1187,47 @@ a:hover { color: var(--gold-light); }
     <div class="cta-success" id="notify-success">
       Thank you! We'll notify you when we launch. If you submitted a show or question, we'll get back to you shortly.
     </div>
+
+    <div class="dealer-toggle">
+      <label>
+        <input type="checkbox" id="dealer-checkbox">
+        Are you a coin/bullion dealer?
+      </label>
+    </div>
+
+    <div class="dealer-signup-form" id="dealer-signup-form">
+      <h3>Dealer Registration</h3>
+      <p>Get listed in our directory and connect with attendees looking to buy, sell, or get appraisals at your shows.</p>
+      <form class="cta-form" id="dealer-reg-form" action="https://formspree.io/f/mykleozw" method="POST">
+        <input type="hidden" name="_subject" value="Coin Show Near Me — Dealer Registration">
+        <input type="hidden" name="form_type" value="dealer_registration">
+        <div class="form-row-2">
+          <input type="text" name="dealer_name" placeholder="Your name" required>
+          <input type="text" name="business_name" placeholder="Business / dealer name" required>
+        </div>
+        <div class="form-row-2">
+          <input type="email" name="email" placeholder="Email address" required>
+          <input type="text" name="phone" placeholder="Phone (optional)">
+        </div>
+        <input type="text" name="website" placeholder="Website or social media (optional)">
+        <select name="specialty">
+          <option value="" disabled selected>Primary specialty</option>
+          <option value="us-coins">US Coins</option>
+          <option value="world-coins">World / Foreign Coins</option>
+          <option value="bullion">Gold & Silver Bullion</option>
+          <option value="currency">Paper Currency</option>
+          <option value="tokens-medals">Tokens & Medals</option>
+          <option value="supplies">Supplies & Accessories</option>
+          <option value="full-service">Full Service (All of the Above)</option>
+        </select>
+        <textarea name="shows_attended" placeholder="Which shows do you regularly attend? (names, cities, or states)"></textarea>
+        <textarea name="message" placeholder="Anything else you'd like us to know? (optional)"></textarea>
+        <button type="submit">Register as a Dealer</button>
+      </form>
+      <div class="cta-success" id="dealer-reg-success">
+        Thank you for registering! We'll be in touch with details about our dealer directory and upcoming features.
+      </div>
+    </div>
   </div>
 </section>
 
@@ -1138,7 +1241,7 @@ a:hover { color: var(--gold-light); }
       <a href="/legal/">Legal</a>
     </div>
     <div class="footer-copy">&copy; {{ site.time | date: '%Y' }} Coin Show Near Me &mdash; All rights reserved.</div>
-    <div class="footer-version">v0.7.3</div>
+    <div class="footer-version">v0.7.4</div>
   </div>
 </footer>
 
@@ -1236,7 +1339,7 @@ document.getElementById('nav-toggle').addEventListener('click', function() {
   }
 })();
 
-/* Dealer portal form */
+/* Quote form (Get Quotes Before the Show) */
 (function() {
   var form = document.getElementById('dealer-form');
   if (form) {
@@ -1251,6 +1354,43 @@ document.getElementById('nav-toggle').addEventListener('click', function() {
         if (response.ok) {
           form.style.display = 'none';
           document.getElementById('dealer-success').style.display = 'block';
+        }
+      });
+    });
+  }
+})();
+
+/* Dealer checkbox toggle */
+(function() {
+  var checkbox = document.getElementById('dealer-checkbox');
+  var dealerForm = document.getElementById('dealer-signup-form');
+  if (checkbox && dealerForm) {
+    checkbox.addEventListener('change', function() {
+      if (this.checked) {
+        dealerForm.classList.add('visible');
+        dealerForm.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      } else {
+        dealerForm.classList.remove('visible');
+      }
+    });
+  }
+})();
+
+/* Dealer registration form */
+(function() {
+  var form = document.getElementById('dealer-reg-form');
+  if (form) {
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      var data = new FormData(form);
+      fetch(form.action, {
+        method: 'POST',
+        body: data,
+        headers: { 'Accept': 'application/json' }
+      }).then(function(response) {
+        if (response.ok) {
+          form.style.display = 'none';
+          document.getElementById('dealer-reg-success').style.display = 'block';
         }
       });
     });


### PR DESCRIPTION
## Summary

Three form changes:

1. **Quote form subject line** fixed: now "Attendee Wants a Quote" instead of "Dealer Portal Inquiry"
2. **Removed "I'm a dealer" option** from the quote form dropdown (dealers have their own form now)
3. **Dealer registration form** added to "Stay in the Loop" section — hidden by default, revealed when user checks "Are you a coin/bullion dealer?" checkbox

### Dealer Registration Form Fields
- Name + Business name
- Email + Phone (optional)
- Website/social media (optional)
- Primary specialty dropdown (US coins, world coins, bullion, currency, tokens, supplies, full service)
- Shows regularly attended
- Additional notes
- Subject line: "Dealer Registration"

All three forms (signup, quote, dealer registration) go to the same Formspree endpoint, distinguished by subject line.

## Version
v0.7.4

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 6d 4h and 70,726 tokens on this with the user in an interactive session.
