### PR TITLE
fix: spot ticker text contrast (v0.7.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG — Coin Shows Near Me (coinshownearme.com)
 
 ## Apr 29, 2026
+- v0.7.5: Improved spot ticker "Updated" text contrast — changed from muted gray to light blue-white for readability on hero gradient
 - v0.7.4: Reworked forms — quote form subject now "Attendee Wants a Quote", added dealer checkbox toggle in Stay in the Loop section that reveals a dealer registration form (name, business, email, phone, website, specialty, shows attended)
 - v0.7.3: Dealer portal inquiry form (Formspree) — name, email, show, interest dropdown, description
 - v0.7.2: Construction banner + nav bar sticky together on scroll, filter bar offset adjusted

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,1 +1,1 @@
-<div class="site-version">v0.7.4</div>
+<div class="site-version">v0.7.5</div>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -350,7 +350,7 @@ a:hover { color: var(--gold-light); }
 .spot-ticker-updated {
   width: 100%;
   text-align: center;
-  color: #64748b;
+  color: #c8d6e5;
   font-size: 0.7rem;
   margin-top: 0.25rem;
 }
@@ -1241,7 +1241,7 @@ a:hover { color: var(--gold-light); }
       <a href="/legal/">Legal</a>
     </div>
     <div class="footer-copy">&copy; {{ site.time | date: '%Y' }} Coin Show Near Me &mdash; All rights reserved.</div>
-    <div class="footer-version">v0.7.4</div>
+    <div class="footer-version">v0.7.5</div>
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary

Spot ticker "Updated X ago . Spot prices per troy oz" text was barely readable — changed from `#64748b` (muted slate gray) to `#c8d6e5` (light blue-white) for better contrast against the navy/blue hero gradient.

## Version
v0.7.5

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 6d 4h and 73,925 tokens on this with the user in an interactive session.
