### PR TITLE
chore: add buffalo monogram pattern to roadmap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,5 +23,6 @@ Know of a coin show not in the directory? Open an issue with:
 - Interactive map view
 - Calendar export (iCal/Google Calendar)
 - Show-finder by date range
+- Buffalo logo monogram pattern — create a micro version of the buffalo nickel logo as a repeating pattern (Gucci-style interlocking monogram). Use as subtle background texture for hero, section dividers, or card backgrounds. Reference: `~/Git/milohiss/inspiration/screenshots/gucci-pattern-reference.jpg`
 
 See `README.md` for the full show list.


### PR DESCRIPTION
## Summary

Add buffalo logo monogram pattern to the roadmap — create a Gucci-style repeating pattern using a micro version of the buffalo nickel logo as a background texture for the site.

Reference saved at `~/Git/milohiss/inspiration/screenshots/gucci-pattern-reference.jpg`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 6d 4h and 76,474 tokens on this with the user in an interactive session.
