### PR TITLE
Show reminder CTA with TCPA-compliant SMS opt-in (v0.7.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # CHANGELOG — Coin Shows Near Me (coinshownearme.com)
 
 ## Apr 29, 2026
+- v0.7.6: Show reminder CTA system — "Never Miss a Coin Show" opt-in cards
+  - In-grid CTA card on homepage (positioned after first row of show cards)
+  - Show-specific reminder CTA on individual show detail pages (pre-fills show name)
+  - TCPA-compliant SMS consent checkbox with legal language
+  - Phone field dynamically required when SMS checkbox is checked
+  - Added SMS and Email Messaging Terms section (Section 9) to Terms of Use
+  - Both CTAs link to Terms of Use #sms-terms anchor and Privacy Policy
+  - All forms submit through Formspree with "Show Reminder Signup" subject
 - v0.7.5: Improved spot ticker "Updated" text contrast — changed from muted gray to light blue-white for readability on hero gradient
 - v0.7.4: Reworked forms — quote form subject now "Attendee Wants a Quote", added dealer checkbox toggle in Stay in the Loop section that reveals a dealer registration form (name, business, email, phone, website, specialty, shows attended)
 - v0.7.3: Dealer portal inquiry form (Formspree) — name, email, show, interest dropdown, description

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,1 +1,1 @@
-<div class="site-version">v0.7.5</div>
+<div class="site-version">v0.7.6</div>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -860,6 +860,105 @@ a:hover { color: var(--gold-light); }
   margin-top: 0.5rem;
 }
 
+/* === Reminder CTA Card (in-grid) === */
+.reminder-cta-card {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  border: 2px solid var(--gold);
+  border-radius: 12px;
+  padding: 1.5rem;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  grid-column: span 1;
+}
+.reminder-cta-card h3 {
+  color: var(--gold-light);
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+  line-height: 1.3;
+}
+.reminder-cta-card p {
+  color: #cbd5e1;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  margin-bottom: 0.75rem;
+}
+.reminder-cta-card .reminder-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.reminder-cta-card .reminder-form input[type="email"],
+.reminder-cta-card .reminder-form input[type="tel"] {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+  outline: none;
+  font-family: inherit;
+}
+.reminder-cta-card .reminder-form input::placeholder { color: #94a3b8; }
+.reminder-cta-card .reminder-form input:focus { border-color: var(--gold-light); }
+.reminder-cta-card .consent-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.reminder-cta-card .consent-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  line-height: 1.4;
+}
+.reminder-cta-card .consent-label input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0.1rem;
+  accent-color: var(--gold);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.reminder-cta-card .consent-label a { color: var(--gold-light); text-decoration: underline; }
+.reminder-cta-card .consent-legal {
+  font-size: 0.65rem;
+  color: #64748b;
+  line-height: 1.4;
+  margin-top: 0.15rem;
+}
+.reminder-cta-card .reminder-form button {
+  background: var(--gold);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.6rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.reminder-cta-card .reminder-form button:hover { background: var(--gold-light); }
+.reminder-cta-card .reminder-form button:disabled {
+  background: #475569;
+  cursor: not-allowed;
+}
+.reminder-cta-success {
+  display: none;
+  background: #065f46;
+  color: #fff;
+  padding: 0.75rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
 /* === No Results === */
 .no-results {
   text-align: center;
@@ -1044,6 +1143,28 @@ a:hover { color: var(--gold-light); }
     </div>
     {% endfor %}
   </div>
+  <!-- Reminder CTA Card (inserted into grid) -->
+  <div class="reminder-cta-card" id="reminder-cta-grid">
+    <h3>Never Miss a Coin Show</h3>
+    <p>Get a reminder a week before upcoming shows near you — by email or text.</p>
+    <form class="reminder-form" id="reminder-form-grid" action="https://formspree.io/f/mykleozw" method="POST">
+      <input type="hidden" name="_subject" value="Coin Show Near Me — Show Reminder Signup">
+      <input type="hidden" name="form_type" value="show_reminder">
+      <input type="email" name="email" placeholder="Email address" required>
+      <input type="tel" name="phone" placeholder="Mobile number (optional, for text reminders)">
+      <div class="consent-group">
+        <label class="consent-label">
+          <input type="checkbox" name="sms_consent" id="sms-consent-grid" value="yes">
+          <span>I agree to receive text message reminders about upcoming coin shows. Msg &amp; data rates may apply. Approx. 2-4 msgs/month. Reply STOP to cancel. <a href="/legal/terms-of-use/#sms-terms" target="_blank">SMS Terms</a> &amp; <a href="/legal/privacy-policy/" target="_blank">Privacy Policy</a>.</span>
+        </label>
+      </div>
+      <button type="submit">Remind Me</button>
+    </form>
+    <div class="reminder-cta-success" id="reminder-grid-success">
+      You're signed up! We'll remind you before upcoming shows.
+    </div>
+  </div>
+
   <div class="no-results" id="no-results">
     <h3>No shows found</h3>
     <p>Try a different search or filter.</p>
@@ -1241,7 +1362,7 @@ a:hover { color: var(--gold-light); }
       <a href="/legal/">Legal</a>
     </div>
     <div class="footer-copy">&copy; {{ site.time | date: '%Y' }} Coin Show Near Me &mdash; All rights reserved.</div>
-    <div class="footer-version">v0.7.5</div>
+    <div class="footer-version">v0.7.6</div>
   </div>
 </footer>
 
@@ -1391,6 +1512,55 @@ document.getElementById('nav-toggle').addEventListener('click', function() {
         if (response.ok) {
           form.style.display = 'none';
           document.getElementById('dealer-reg-success').style.display = 'block';
+        }
+      });
+    });
+  }
+})();
+
+/* Reminder CTA — position in grid after first row and handle submit */
+(function() {
+  var ctaCard = document.getElementById('reminder-cta-grid');
+  var grid = document.getElementById('card-grid');
+  if (ctaCard && grid) {
+    /* Move CTA into the grid after the 4th card (end of first row on desktop) */
+    var cards = grid.querySelectorAll('.show-card');
+    if (cards.length > 3) {
+      cards[3].parentNode.insertBefore(ctaCard, cards[3].nextSibling);
+    } else {
+      grid.appendChild(ctaCard);
+    }
+  }
+
+  /* Phone field required when SMS checkbox is checked */
+  var smsCheck = document.getElementById('sms-consent-grid');
+  if (smsCheck) {
+    var phoneField = smsCheck.closest('form').querySelector('input[name="phone"]');
+    smsCheck.addEventListener('change', function() {
+      if (this.checked) {
+        phoneField.setAttribute('required', '');
+        phoneField.setAttribute('placeholder', 'Mobile number (required for text reminders)');
+      } else {
+        phoneField.removeAttribute('required');
+        phoneField.setAttribute('placeholder', 'Mobile number (optional, for text reminders)');
+      }
+    });
+  }
+
+  /* Form submit */
+  var form = document.getElementById('reminder-form-grid');
+  if (form) {
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      var data = new FormData(form);
+      fetch(form.action, {
+        method: 'POST',
+        body: data,
+        headers: { 'Accept': 'application/json' }
+      }).then(function(response) {
+        if (response.ok) {
+          form.style.display = 'none';
+          document.getElementById('reminder-grid-success').style.display = 'block';
         }
       });
     });

--- a/_layouts/show.html
+++ b/_layouts/show.html
@@ -76,6 +76,69 @@ layout: default
 </p>
 </div>
 
+<!-- Show Reminder CTA -->
+<div style="background:linear-gradient(135deg, var(--coin-navy) 0%, var(--coin-navy-light) 100%);color:#f1f5f9;padding:1.5rem;border-radius:10px;margin:2rem 0;border:2px solid var(--coin-gold);">
+  <p style="margin:0 0 0.25rem;font-size:1.1rem;font-weight:700;color:var(--coin-gold-light);">Don't Forget About This Show!</p>
+  <p style="margin:0 0 1rem;font-size:0.9rem;color:#cbd5e1;">Get a reminder a week before <strong>{{ show.name }}</strong> — by email or text message.</p>
+  <form id="show-reminder-form" action="https://formspree.io/f/mykleozw" method="POST" style="display:flex;flex-direction:column;gap:0.5rem;">
+    <input type="hidden" name="_subject" value="Coin Show Near Me — Show Reminder Signup">
+    <input type="hidden" name="form_type" value="show_reminder">
+    <input type="hidden" name="show_name" value="{{ show.name }}">
+    <input type="hidden" name="show_id" value="{{ show.id }}">
+    <input type="hidden" name="show_city" value="{{ show.city }}, {{ show.state_name }}">
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.5rem;">
+      <input type="email" name="email" placeholder="Email address" required style="padding:0.6rem 0.8rem;border:1px solid rgba(255,255,255,0.2);border-radius:6px;font-size:0.88rem;background:rgba(255,255,255,0.1);color:#fff;outline:none;font-family:inherit;">
+      <input type="tel" name="phone" placeholder="Mobile number (optional)" style="padding:0.6rem 0.8rem;border:1px solid rgba(255,255,255,0.2);border-radius:6px;font-size:0.88rem;background:rgba(255,255,255,0.1);color:#fff;outline:none;font-family:inherit;">
+    </div>
+    <label style="display:flex;align-items:flex-start;gap:0.5rem;cursor:pointer;font-size:0.75rem;color:#94a3b8;line-height:1.4;">
+      <input type="checkbox" name="sms_consent" id="sms-consent-show" value="yes" style="width:1rem;height:1rem;margin-top:0.1rem;accent-color:var(--coin-gold);cursor:pointer;flex-shrink:0;">
+      <span>I agree to receive text message reminders about upcoming coin shows. Msg &amp; data rates may apply. Approx. 2-4 msgs/month. Reply STOP to cancel. <a href="/legal/terms-of-use/#sms-terms" style="color:var(--coin-gold-light);text-decoration:underline;">SMS Terms</a> &amp; <a href="/legal/privacy-policy/" style="color:var(--coin-gold-light);text-decoration:underline;">Privacy Policy</a>.</span>
+    </label>
+    <p style="font-size:0.65rem;color:#64748b;line-height:1.4;margin:0;">By submitting, you also consent to receive email reminders. You can unsubscribe at any time.</p>
+    <button type="submit" style="background:var(--coin-gold);color:#fff;border:none;border-radius:6px;padding:0.65rem 1.5rem;font-size:0.9rem;font-weight:700;cursor:pointer;align-self:flex-start;">Remind Me About This Show</button>
+  </form>
+  <div id="show-reminder-success" style="display:none;background:#065f46;color:#fff;padding:0.75rem;border-radius:6px;font-size:0.88rem;text-align:center;margin-top:0.5rem;">
+    You're signed up! We'll remind you before {{ show.name }}.
+  </div>
+</div>
+
+<script>
+(function() {
+  /* Phone required when SMS checked */
+  var smsCheck = document.getElementById('sms-consent-show');
+  if (smsCheck) {
+    var phoneField = smsCheck.closest('form').querySelector('input[name="phone"]');
+    smsCheck.addEventListener('change', function() {
+      if (this.checked) {
+        phoneField.setAttribute('required', '');
+        phoneField.setAttribute('placeholder', 'Mobile number (required for text reminders)');
+      } else {
+        phoneField.removeAttribute('required');
+        phoneField.setAttribute('placeholder', 'Mobile number (optional)');
+      }
+    });
+  }
+  /* Form submit */
+  var form = document.getElementById('show-reminder-form');
+  if (form) {
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      var data = new FormData(form);
+      fetch(form.action, {
+        method: 'POST',
+        body: data,
+        headers: { 'Accept': 'application/json' }
+      }).then(function(response) {
+        if (response.ok) {
+          form.style.display = 'none';
+          document.getElementById('show-reminder-success').style.display = 'block';
+        }
+      });
+    });
+  }
+})();
+</script>
+
 <h2>More Coin Shows Near {{ show.city }}</h2>
 <p>See all <a href="{{ site.baseurl }}/cities/{{ show.city_slug }}/">coin shows in {{ show.city }}</a> or browse <a href="{{ site.baseurl }}/states/{% for state in site.data.states %}{% if state.abbrev == show.state %}{{ state.slug }}{% endif %}{% endfor %}/">all coin shows in {{ show.state_name }}</a>.</p>
 

--- a/legal/terms-of-use.md
+++ b/legal/terms-of-use.md
@@ -13,7 +13,7 @@ breadcrumb_current: "Terms of Use"
 # Terms of Use
 
 **Effective Date:** April 15, 2026
-**Last Updated:** April 15, 2026
+**Last Updated:** April 29, 2026
 
 Please read these Terms of Use ("Terms") carefully before using the Coin Show Near Me website located at coinshownearme.com (the "Site"), including all subdomains, pages, tools, services, and features offered through the Site (collectively, the "Platform"). The Platform is operated by Coin Show Near Me ("we," "us," or "our").
 
@@ -174,7 +174,43 @@ You agree not to submit content that is:
 
 ---
 
-## 9. Prohibited Uses
+## 9. SMS and Email Messaging Terms {#sms-terms}
+
+### 9.1 Consent to Receive Messages
+
+By providing your mobile phone number and checking the SMS consent box on our Platform, you expressly consent to receive recurring automated text messages (SMS/MMS) from Coin Show Near Me related to coin show reminders, event updates, and related notifications. Consent is not a condition of any purchase. You may receive approximately 2 to 4 messages per month, though frequency may vary.
+
+### 9.2 Message and Data Rates
+
+Message and data rates may apply depending on your mobile carrier and plan. Coin Show Near Me is not responsible for any charges incurred from your carrier as a result of receiving text messages.
+
+### 9.3 How to Opt Out
+
+You may opt out of receiving text messages at any time by replying **STOP** to any message you receive from us. After opting out, you will receive one final confirmation message. You will no longer receive text messages from us unless you re-subscribe.
+
+### 9.4 Help
+
+For help with text messages, reply **HELP** to any message you receive from us, or contact us at legal@coinshownearme.com.
+
+### 9.5 Supported Carriers
+
+Major US carriers are supported, including but not limited to AT&T, Verizon, T-Mobile, Sprint, and their affiliates. Coin Show Near Me is not responsible for delayed or undelivered messages due to carrier issues.
+
+### 9.6 Email Communications
+
+By providing your email address through any form on the Platform, you consent to receive email communications from Coin Show Near Me, including coin show reminders, event updates, and feature announcements. You may unsubscribe from email communications at any time by clicking the "unsubscribe" link included in every email or by contacting us at legal@coinshownearme.com.
+
+### 9.7 Privacy
+
+Your phone number and email address will not be shared with third parties for marketing purposes. For more information on how we handle your data, see our [Privacy Policy](/legal/privacy-policy/).
+
+### 9.8 Modifications
+
+We reserve the right to modify this SMS messaging program at any time. Any changes will be reflected in an updated version of these Terms.
+
+---
+
+## 10. Prohibited Uses
 
 You agree not to:
 - Use the Platform for any unlawful purpose
@@ -189,53 +225,53 @@ You agree not to:
 
 ---
 
-## 10. Dispute Resolution
+## 11. Dispute Resolution
 
-### 10.1 Between Users
+### 11.1 Between Users
 
 Disputes between users (Dealers, Sellers, Attendees, Promoters) are exclusively between those parties. **We are not obligated to mediate, arbitrate, or resolve any dispute between users.** We may, at our sole discretion, provide reasonable assistance, but have no obligation to do so.
 
-### 10.2 Between You and Us
+### 11.2 Between You and Us
 
 Any dispute arising from or related to these Terms or your use of the Platform shall be resolved through binding arbitration administered by the American Arbitration Association (AAA) under its Consumer Arbitration Rules. The arbitration shall take place in Orange County, California. **You agree to waive any right to a jury trial and to participate in a class action lawsuit.**
 
-### 10.3 Governing Law
+### 11.3 Governing Law
 
 These Terms shall be governed by and construed in accordance with the laws of the State of California, without regard to conflict of law principles.
 
 ---
 
-## 11. Intellectual Property
+## 12. Intellectual Property
 
 All content, design, code, trademarks, logos, and other intellectual property on the Platform (excluding User Content) is owned by or licensed to Coin Show Near Me and is protected by applicable intellectual property laws. You may not reproduce, distribute, modify, or create derivative works from any Platform content without our prior written consent.
 
 ---
 
-## 12. Termination
+## 13. Termination
 
 We may terminate or suspend your access to the Platform at any time, for any reason, without notice. Upon termination, your right to use the Platform ceases immediately. Sections that by their nature should survive termination (including Limitation of Liability, Indemnification, Disclaimer of Warranties, and Dispute Resolution) shall survive.
 
 ---
 
-## 13. Modifications to Terms
+## 14. Modifications to Terms
 
 We reserve the right to modify these Terms at any time. Material changes will be posted on the Platform with an updated "Last Updated" date. Your continued use of the Platform after any modification constitutes acceptance of the modified Terms.
 
 ---
 
-## 14. Severability
+## 15. Severability
 
 If any provision of these Terms is found to be unenforceable, the remaining provisions shall continue in full force and effect.
 
 ---
 
-## 15. Entire Agreement
+## 16. Entire Agreement
 
 These Terms, together with our [Privacy Policy](/legal/privacy-policy/) and any other legal notices published on the Platform, constitute the entire agreement between you and Coin Show Near Me regarding your use of the Platform.
 
 ---
 
-## 16. Contact
+## 17. Contact
 
 For questions about these Terms, contact us at:
 


### PR DESCRIPTION
## What Changed

- **Homepage**: Added a "Never Miss a Coin Show" CTA card that appears in the show card grid (after the first row). Navy/gold themed, includes email + phone fields, SMS consent checkbox with TCPA-compliant language.
- **Show detail pages**: Added a show-specific reminder CTA — "Don't Forget About This Show!" — that pre-fills the show name, city, and ID. Same consent checkbox and legal language.
- **Terms of Use**: Added Section 9 — SMS and Email Messaging Terms — covering consent, message frequency (~2-4/month), STOP/HELP instructions, carrier support, opt-out, and privacy. Renumbered all subsequent sections (10-17). Updated Last Updated date.
- **Version bump**: v0.7.5 → v0.7.6

## SMS Consent Language (on both CTAs)

> I agree to receive text message reminders about upcoming coin shows. Msg & data rates may apply. Approx. 2-4 msgs/month. Reply STOP to cancel. SMS Terms & Privacy Policy.

## How It Works

- Phone field is optional by default (email-only reminders)
- When SMS checkbox is checked, phone field becomes required
- All submissions go through Formspree (same endpoint) with subject "Show Reminder Signup"
- Show detail page CTA sends show_name, show_id, and show_city as hidden fields

## Files Changed

- `_layouts/homepage.html` — CSS + HTML + JS for in-grid reminder CTA
- `_layouts/show.html` — show-specific reminder CTA section
- `legal/terms-of-use.md` — new Section 9 (SMS/Email Messaging Terms)
- `_includes/nav_footer_custom.html` — version bump
- `CHANGELOG.md` — v0.7.6 entry

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 6d 13h and 95,693 tokens on this with the user in an interactive session.
