### PR TITLE
Stay in the Loupe wordplay (v0.7.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG — Coin Shows Near Me (coinshownearme.com)
 
 ## Apr 29, 2026
+- v0.7.7: Changed "Stay in the Loop" to "Stay in the Loupe" — coin collector wordplay (a loupe is the magnifying glass used to examine coins)
 - v0.7.6: Show reminder CTA system — "Never Miss a Coin Show" opt-in cards
   - In-grid CTA card on homepage (positioned after first row of show cards)
   - Show-specific reminder CTA on individual show detail pages (pre-fills show name)

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,1 +1,1 @@
-<div class="site-version">v0.7.6</div>
+<div class="site-version">v0.7.7</div>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -1296,7 +1296,7 @@ a:hover { color: var(--gold-light); }
 <!-- CTA / Signup -->
 <section class="cta-section" id="signup">
   <div class="cta-inner">
-    <h2>Stay in the <span>Loop</span></h2>
+    <h2>Stay in the <span>Loupe</span></h2>
     <p>Get notified when we launch new features, or submit a show we're missing.</p>
     <form class="cta-form" id="notify-form" action="https://formspree.io/f/mykleozw" method="POST">
       <input type="hidden" name="_subject" value="Coin Show Near Me — New Signup">
@@ -1362,7 +1362,7 @@ a:hover { color: var(--gold-light); }
       <a href="/legal/">Legal</a>
     </div>
     <div class="footer-copy">&copy; {{ site.time | date: '%Y' }} Coin Show Near Me &mdash; All rights reserved.</div>
-    <div class="footer-version">v0.7.6</div>
+    <div class="footer-version">v0.7.7</div>
   </div>
 </footer>
 


### PR DESCRIPTION
## What Changed

Changed "Stay in the **Loop**" to "Stay in the **Loupe**" in the signup section heading on the homepage.

A loupe is the small magnifying glass coin collectors use to examine coins — fits the audience perfectly.

Version bump: v0.7.6 → v0.7.7

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 6d 13h and 98,673 tokens on this with the user in an interactive session.
