### PR TITLE
Navigation overhaul with dropdown menus (v0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG — Coin Shows Near Me (coinshownearme.com)
 
 ## Apr 29, 2026
+- v0.8.1: Navigation overhaul + driving directions fix
+  - Homepage nav now has dropdown menus: Find Shows (Browse by State, This Weekend, Major Shows), Tools (Melt Calculator, Sales Tax Guide), Guides (Beginner's Guide, Inherited Coins), Sign Up CTA
+  - Dropdowns work on mobile (expand inline in hamburger menu)
+  - Sidebar nav (inner pages) now shows: Browse by State, This Weekend, Tools (with children), Guides (with children)
+  - Added Tools index page and made melt calc + tax guide sidebar-visible
+  - Fixed: Driving Directions button now hidden when show has no venue/address
+  - Cleaner nav titles: shortened sidebar labels for readability
 - v0.8.0: Major content expansion — 4 new sections, 55+ new pages
   - **State Sales Tax Guide** — main index page with search/filter + 51 individual state pages. Covers bullion/coin exemption status, thresholds, effective dates, tax authority links. Data-driven from `_data/state_tax.yml`.
   - **Get Driving Directions** button on every show detail page (Google Maps link with venue pre-filled) + tax status badge linking to state's tax guide

--- a/_config.yml
+++ b/_config.yml
@@ -26,8 +26,8 @@ nav_sort: order
 nav_external_links: []
 
 aux_links:
-  "Melt Calculator":
-    - "/tools/melt-value-calculator/"
+  "Sign Up":
+    - "/#signup"
 aux_links_new_tab: false
 
 google_site_verification: ZW60JDUpZFD9rhZv8KgiklQ65RSr5jyyxku3686lHbo

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,1 +1,1 @@
-<div class="site-version">v0.8.0</div>
+<div class="site-version">v0.8.1</div>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -120,6 +120,45 @@ a:hover { color: var(--gold-light); }
 }
 .nav-cta:hover { background: var(--gold-light) !important; }
 
+/* Nav dropdowns */
+.nav-dropdown { position: relative; }
+.nav-dropdown > a { display: flex; align-items: center; gap: 0.3rem; }
+.nav-dropdown > a::after { content: "\25BE"; font-size: 0.65rem; opacity: 0.7; }
+.nav-dropdown-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--navy);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 8px;
+  padding: 0.5rem 0;
+  min-width: 200px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+  z-index: 200;
+  margin-top: 0.5rem;
+}
+.nav-dropdown:hover .nav-dropdown-menu { display: block; }
+.nav-dropdown-menu a {
+  display: block;
+  padding: 0.5rem 1.25rem;
+  color: #cbd5e1 !important;
+  font-size: 0.85rem !important;
+  font-weight: 500 !important;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+}
+.nav-dropdown-menu a:hover {
+  background: rgba(255,255,255,0.08);
+  color: var(--gold-light) !important;
+}
+.nav-dropdown-menu .dropdown-divider {
+  height: 1px;
+  background: rgba(255,255,255,0.08);
+  margin: 0.35rem 0;
+}
+
 /* Mobile nav toggle */
 .nav-toggle { display: none; background: none; border: none; color: var(--gold-light); font-size: 1.5rem; cursor: pointer; }
 
@@ -981,8 +1020,23 @@ a:hover { color: var(--gold-light); }
     background: var(--navy);
     padding: 1rem 1.5rem;
     border-bottom: 2px solid var(--gold);
+    gap: 0;
   }
+  .top-nav-links.open li { padding: 0.4rem 0; }
   .nav-toggle { display: block; }
+  .nav-dropdown-menu {
+    position: static;
+    transform: none;
+    box-shadow: none;
+    border: none;
+    margin-top: 0;
+    padding: 0 0 0 1rem;
+    min-width: auto;
+    background: transparent;
+  }
+  .nav-dropdown > a::after { content: ""; }
+  .top-nav-links.open .nav-dropdown .nav-dropdown-menu { display: block; }
+  .nav-dropdown-menu .dropdown-divider { display: none; }
 
   .hero { padding: 2.5rem 1rem 2rem; }
   .hero h1 { font-size: 1.7rem; }
@@ -1025,9 +1079,30 @@ a:hover { color: var(--gold-light); }
       </a>
       <button class="nav-toggle" id="nav-toggle" aria-label="Menu">&#9776;</button>
       <ul class="top-nav-links" id="nav-links">
-        <li><a href="/states/">Browse by State</a></li>
-        <li><a href="/coin-shows-this-weekend/">This Weekend</a></li>
-        <li><a href="/tools/melt-value-calculator/" class="nav-cta">Melt Calculator</a></li>
+        <li class="nav-dropdown">
+          <a href="/states/">Find Shows</a>
+          <div class="nav-dropdown-menu">
+            <a href="/states/">Browse by State</a>
+            <a href="/coin-shows-this-weekend/">This Weekend</a>
+            <div class="dropdown-divider"></div>
+            <a href="/#featured">Major Shows</a>
+          </div>
+        </li>
+        <li class="nav-dropdown">
+          <a href="/tools/melt-value-calculator/">Tools</a>
+          <div class="nav-dropdown-menu">
+            <a href="/tools/melt-value-calculator/">Melt Value Calculator</a>
+            <a href="/tools/sales-tax-guide/">Sales Tax by State</a>
+          </div>
+        </li>
+        <li class="nav-dropdown">
+          <a href="/guides/">Guides</a>
+          <div class="nav-dropdown-menu">
+            <a href="/guides/beginners-guide/">Beginner's Guide</a>
+            <a href="/guides/inherited-coin-collection/">Inherited Coins</a>
+          </div>
+        </li>
+        <li><a href="#signup" class="nav-cta">Sign Up</a></li>
       </ul>
     </div>
   </nav>
@@ -1364,7 +1439,7 @@ a:hover { color: var(--gold-light); }
       <a href="/legal/disclaimer/">Disclaimer</a>
     </div>
     <div class="footer-copy">&copy; {{ site.time | date: '%Y' }} Coin Show Near Me &mdash; All rights reserved.</div>
-    <div class="footer-version">v0.8.0</div>
+    <div class="footer-version">v0.8.1</div>
   </div>
 </footer>
 

--- a/_layouts/show.html
+++ b/_layouts/show.html
@@ -47,9 +47,11 @@ layout: default
     {% endif %}
   </table>
   <div style="margin-top:0.75rem;padding-top:0.75rem;border-top:1px solid #e5e7eb;">
+    {% if show.venue and show.venue != "" %}
     <a href="https://www.google.com/maps/dir/?api=1&destination={{ show.venue | url_encode }}+{{ show.city | url_encode }}+{{ show.state_name | url_encode }}" target="_blank" rel="noopener noreferrer" style="display:inline-flex;align-items:center;gap:0.4rem;background:#1a2332;color:#fff;padding:0.5rem 1.25rem;border-radius:6px;font-size:0.88rem;font-weight:600;text-decoration:none;transition:background 0.2s;">
       &#128663; Get Driving Directions
     </a>
+    {% endif %}
     {% assign state_slug = nil %}{% for st in site.data.states %}{% if st.abbrev == show.state %}{% assign state_slug = st.slug %}{% endif %}{% endfor %}
     {% for tax in site.data.state_tax %}{% if tax.abbrev == show.state %}
     <a href="{{ site.baseurl }}/tools/sales-tax-guide/{{ tax.slug }}/" style="display:inline-flex;align-items:center;gap:0.4rem;background:#f8fafc;color:#555;padding:0.5rem 1.25rem;border-radius:6px;font-size:0.85rem;font-weight:600;text-decoration:none;border:1px solid #e5ddd0;margin-left:0.5rem;transition:all 0.2s;">

--- a/coin-shows-this-weekend.md
+++ b/coin-shows-this-weekend.md
@@ -1,6 +1,6 @@
 ---
 layout: weekend
-title: "Coin Shows This Weekend — Find a Coin Show Near You"
+title: "This Weekend"
 seo_title: "Coin Shows This Weekend — Upcoming Coin Shows Near You | Coin Show Near Me"
 seo_description: "Find coin shows happening this weekend and next weekend across the United States. Updated weekly with dates, venues, and locations for upcoming coin shows."
 permalink: /coin-shows-this-weekend/

--- a/guides/beginners-guide.md
+++ b/guides/beginners-guide.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: "Beginner's Guide to Coin Shows"
+title: "Beginner's Guide"
 seo_title: "Beginner's Guide to Coin Shows — What to Expect, Tips & Etiquette | Coin Show Near Me"
 seo_description: "First time at a coin show? Learn what to expect, how to negotiate with dealers, what to bring, coin show etiquette, and insider tips for getting the best deals."
 permalink: /guides/beginners-guide/
-nav_exclude: true
+parent: "Guides"
+nav_order: 1
 breadcrumb_parent: "Guides"
 breadcrumb_parent_url: "/guides/"
 breadcrumb_current: "Beginner's Guide"

--- a/guides/index.md
+++ b/guides/index.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: "Coin Collecting Guides"
+title: "Guides"
 seo_title: "Coin Collecting Guides & Resources | Coin Show Near Me"
 seo_description: "Free guides for coin collectors — beginner tips, coin show etiquette, inherited collection advice, and more."
 permalink: /guides/
-nav_exclude: true
+nav_order: 5
+has_children: true
 breadcrumb_current: "Guides"
 ---
 

--- a/guides/inherited-coin-collection.md
+++ b/guides/inherited-coin-collection.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: "What to Do With an Inherited Coin Collection"
+title: "Inherited Coins"
 seo_title: "Inherited Coin Collection? What to Do, How to Value & Where to Sell | Coin Show Near Me"
 seo_description: "Inherited coins or a coin collection? Don't clean them. Learn how to value, protect, and sell inherited coins — common mistakes, tax rules, and where to get honest appraisals."
 permalink: /guides/inherited-coin-collection/
-nav_exclude: true
+parent: "Guides"
+nav_order: 2
 breadcrumb_parent: "Guides"
 breadcrumb_parent_url: "/guides/"
 breadcrumb_current: "Inherited Coin Collection"

--- a/states/index.md
+++ b/states/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Coin Shows by State — Complete US Directory"
+title: "Browse by State"
 seo_title: "Coin Shows by State — Find Coin Shows in Every US State | Coin Show Near Me"
 seo_description: "Browse coin shows in all 50 US states. Find upcoming coin shows, expos, and numismatic conventions near you with dates, venues, and details."
 permalink: /states/

--- a/tools/index.md
+++ b/tools/index.md
@@ -1,0 +1,26 @@
+---
+layout: default
+title: "Tools"
+seo_title: "Coin Collecting Tools & Calculators | Coin Show Near Me"
+seo_description: "Free tools for coin collectors — melt value calculator, state sales tax guide, and more."
+permalink: /tools/
+nav_order: 4
+has_children: true
+breadcrumb_current: "Tools"
+---
+
+# Coin Collecting Tools
+
+Free tools to help you make smarter decisions when buying and selling coins.
+
+---
+
+## [Melt Value Calculator](/tools/melt-value-calculator/)
+
+Calculate the precious metal value of your silver and gold coins based on current spot prices. Know the baseline value before negotiating with dealers.
+
+---
+
+## [State Sales Tax Guide](/tools/sales-tax-guide/)
+
+Find out if your state taxes purchases of coins, bullion, and precious metals. Covers all 50 states with exemption details, thresholds, and links to tax authority websites.

--- a/tools/melt-value-calculator.md
+++ b/tools/melt-value-calculator.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: "Coin Melt Value Calculator — What Are Your Coins Worth in Metal?"
+title: "Melt Value Calculator"
 seo_title: "Coin Melt Value Calculator — Silver & Gold Coin Melt Values | Coin Show Near Me"
 seo_description: "Calculate the melt value of US silver and gold coins. Instant calculator for pre-1965 silver quarters, dimes, half dollars, silver dollars, and gold coins. Get an offer from a local dealer."
 permalink: /tools/melt-value-calculator/
-nav_order: 4
+parent: "Tools"
+nav_order: 1
 breadcrumb_current: "Melt Value Calculator"
 ---
 

--- a/tools/sales-tax-guide/index.md
+++ b/tools/sales-tax-guide/index.md
@@ -1,10 +1,11 @@
 ---
 layout: default
-title: "State Sales Tax Guide for Coins & Precious Metals"
+title: "Sales Tax Guide"
 seo_title: "Sales Tax on Coins & Precious Metals by State (2026) | Coin Show Near Me"
 seo_description: "Complete 50-state guide to sales tax on gold, silver, bullion, and coins. Find out if your state taxes precious metals purchases and what exemptions apply."
 permalink: /tools/sales-tax-guide/
-nav_exclude: true
+parent: "Tools"
+nav_order: 2
 breadcrumb_parent: "Tools"
 breadcrumb_parent_url: "/tools/"
 breadcrumb_current: "Sales Tax Guide"


### PR DESCRIPTION
## What Changed (v0.8.1)

### Navigation Overhaul

**Homepage nav bar** now has 3 dropdown menus + a Sign Up CTA:

- **Find Shows** → Browse by State, This Weekend, Major Shows
- **Tools** → Melt Value Calculator, Sales Tax by State  
- **Guides** → Beginner's Guide, Inherited Coins
- **Sign Up** (gold CTA button)

Dropdowns appear on hover (desktop) and expand inline on mobile hamburger menu.

**Sidebar nav** (inner pages via just-the-docs) now shows a structured hierarchy:
- Browse by State
- This Weekend
- Tools → Melt Value Calculator, Sales Tax Guide
- Guides → Beginner's Guide, Inherited Coins

### Driving Directions Fix

"Get Driving Directions" button is now hidden on show pages where the venue field is empty. Previously it would show a useless Google Maps link with just city/state.

### Files Changed

- `_layouts/homepage.html` — dropdown CSS + new nav HTML
- `_layouts/show.html` — venue conditional on directions button
- `_config.yml` — updated aux_links
- `tools/index.md` (new) — Tools parent page
- `guides/index.md`, `guides/beginners-guide.md`, `guides/inherited-coin-collection.md` — nav settings
- `tools/melt-value-calculator.md`, `tools/sales-tax-guide/index.md` — nav settings
- `states/index.md`, `coin-shows-this-weekend.md` — cleaner nav titles
- `_includes/nav_footer_custom.html` — version bump

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 6d 15h and 142,359 tokens on this with the user in an interactive session.
