### PR TITLE
Fix CTA button text, add Contact Us, remove inbox from nav, replace placeholder emails

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,3 +41,5 @@ exclude:
   - TODO.md
   - CHANGELOG.md
   - LICENSE
+  - AGENTS.md
+  - inbox/

--- a/blog/index.md
+++ b/blog/index.md
@@ -15,7 +15,7 @@ breadcrumb_current: "Blog"
     <p style="font-size:2.5rem;margin:0 0 0.75rem;">Coming Soon</p>
     <p style="color:#cbd5e1;font-size:1rem;line-height:1.6;margin:0 0 1.5rem;">We're working on articles about coin collecting, market updates, show recaps, dealer spotlights, and tips for buyers and sellers.</p>
     <p style="color:#94a3b8;font-size:0.9rem;margin:0 0 1.5rem;">Want to know when we launch?</p>
-    <a href="/#signup" style="display:inline-block;background:#b8860b;color:#fff;padding:0.65rem 2rem;border-radius:6px;font-weight:700;font-size:0.95rem;text-decoration:none;">Sign Up for Updates</a>
+    <a href="/#signup" class="cta-btn" style="display:inline-block;background:#b8860b;color:#fff;padding:0.65rem 2rem;border-radius:6px;font-weight:700;font-size:0.95rem;text-decoration:none;">Sign Up for Updates</a>
   </div>
 </div>
 

--- a/contact/index.md
+++ b/contact/index.md
@@ -1,0 +1,79 @@
+---
+layout: default
+title: "Contact Us"
+seo_title: "Contact Us | Coin Show Near Me"
+seo_description: "Get in touch with Coin Show Near Me. Submit a show, report an error, ask a question, or register as a dealer."
+permalink: /contact/
+nav_order: 8
+breadcrumb_current: "Contact Us"
+---
+
+# Contact Us
+
+Have a question, found an error, or want to submit a show? We'd love to hear from you.
+
+<div class="notify-section">
+<h3>Send Us a Message</h3>
+<p>Fill out the form below and we'll get back to you as soon as we can.</p>
+
+<form class="notify-form" id="contact-form" action="https://formspree.io/f/mykleozw" method="POST">
+<input type="hidden" name="_subject" value="Coin Show Near Me — Contact Form">
+<input type="hidden" name="form_type" value="contact">
+<div class="form-row">
+<input type="text" name="name" placeholder="Your name" style="background:#fff;color:#111;">
+<input type="email" name="email" placeholder="Email address" required style="background:#fff;color:#111;">
+</div>
+<select name="reason" style="width:100%;padding:0.6rem 0.75rem;border:1px solid var(--coin-border);border-radius:6px;font-size:0.9rem;background:#fff;color:#111;margin-top:0.5rem;">
+<option value="">What can we help with?</option>
+<option value="submit-show">Submit a coin show</option>
+<option value="report-error">Report an error or outdated listing</option>
+<option value="dealer-registration">Register as a dealer</option>
+<option value="general-question">General question</option>
+<option value="feedback">Feedback or suggestion</option>
+<option value="other">Other</option>
+</select>
+<textarea name="message" placeholder="Your message..." style="background:#fff;color:#111;margin-top:0.5rem;"></textarea>
+<button type="submit">Send Message</button>
+</form>
+<div class="notify-success" id="contact-success" style="background:#065f46;margin-top:0.5rem;">
+Thank you for reaching out! We'll get back to you shortly.
+</div>
+</div>
+
+---
+
+## Other Ways to Reach Us
+
+- **Submit a show we're missing** -- use the form above or [sign up for updates](/#signup) and mention the show
+- **Report an error** -- dates, venues, or organizer details that need updating? Let us know
+- **Dealer registration** -- want to be listed in our [dealer directory](/dealers/)? Fill out the form above or [register here](/#signup)
+
+---
+
+## Quick Links
+
+- [Find Coin Shows by State](/states/)
+- [Coin Shows This Weekend](/coin-shows-this-weekend/)
+- [Melt Value Calculator](/tools/melt-value-calculator/)
+- [Beginner's Guide to Coin Shows](/guides/beginners-guide/)
+- [Find a Dealer](/dealers/)
+
+<script>
+var form = document.getElementById('contact-form');
+if (form) {
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    var data = new FormData(form);
+    fetch(form.action, {
+      method: 'POST',
+      body: data,
+      headers: { 'Accept': 'application/json' }
+    }).then(function(response) {
+      if (response.ok) {
+        form.style.display = 'none';
+        document.getElementById('contact-success').style.display = 'block';
+      }
+    });
+  });
+}
+</script>

--- a/dealers/index.md
+++ b/dealers/index.md
@@ -74,7 +74,7 @@ Browse trusted coin dealers, bullion sellers, and auction houses. Search by name
     <li style="color:#94a3b8;font-size:0.85rem;padding:0.25rem 0;padding-left:1.25rem;position:relative;"><span style="position:absolute;left:0;color:#daa520;font-weight:700;">&#10003;</span> Receive pre-show offer requests from sellers</li>
     <li style="color:#94a3b8;font-size:0.85rem;padding:0.25rem 0;padding-left:1.25rem;position:relative;"><span style="position:absolute;left:0;color:#daa520;font-weight:700;">&#10003;</span> Link to your website and show your specialties</li>
   </ul>
-  <a href="/#signup" style="display:inline-block;background:#b8860b;color:#fff;padding:0.65rem 2rem;border-radius:6px;font-weight:700;font-size:0.95rem;text-decoration:none;">Register as a Dealer</a>
+  <a href="/#signup" class="cta-btn" style="display:inline-block;background:#b8860b;color:#fff;padding:0.65rem 2rem;border-radius:6px;font-weight:700;font-size:0.95rem;text-decoration:none;">Register as a Dealer</a>
 </div>
 
 ## How to Choose a Dealer

--- a/legal/disclaimer.md
+++ b/legal/disclaimer.md
@@ -111,4 +111,4 @@ Please see our [Terms of Use](/legal/terms-of-use/) for complete limitation of l
 Questions about these disclaimers may be directed to:
 
 **Coin Show Near Me**
-Email: legal@coinshownearme.com
+[Contact us here](/contact/)

--- a/legal/privacy-policy.md
+++ b/legal/privacy-policy.md
@@ -111,7 +111,7 @@ Depending on your jurisdiction, you may have the right to:
 
 If you are a California resident, you have additional rights under the California Consumer Privacy Act (CCPA) and California Privacy Rights Act (CPRA), including the right to know what personal information we collect, the right to delete, and the right to opt out of the sale of personal information. **We do not sell personal information.**
 
-To exercise your rights, contact us at privacy@coinshownearme.com.
+To exercise your rights, [contact us](/contact/).
 
 ---
 
@@ -150,7 +150,7 @@ We may update this Privacy Policy from time to time. Material changes will be po
 For privacy-related questions or to exercise your rights:
 
 **Coin Show Near Me**
-Email: privacy@coinshownearme.com
+[Contact us here](/contact/)
 
 ---
 

--- a/legal/terms-of-use.md
+++ b/legal/terms-of-use.md
@@ -190,7 +190,7 @@ You may opt out of receiving text messages at any time by replying **STOP** to a
 
 ### 9.4 Help
 
-For help with text messages, reply **HELP** to any message you receive from us, or contact us at legal@coinshownearme.com.
+For help with text messages, reply **HELP** to any message you receive from us, or [contact us](/contact/).
 
 ### 9.5 Supported Carriers
 
@@ -198,7 +198,7 @@ Major US carriers are supported, including but not limited to AT&T, Verizon, T-M
 
 ### 9.6 Email Communications
 
-By providing your email address through any form on the Platform, you consent to receive email communications from Coin Show Near Me, including coin show reminders, event updates, and feature announcements. You may unsubscribe from email communications at any time by clicking the "unsubscribe" link included in every email or by contacting us at legal@coinshownearme.com.
+By providing your email address through any form on the Platform, you consent to receive email communications from Coin Show Near Me, including coin show reminders, event updates, and feature announcements. You may unsubscribe from email communications at any time by clicking the "unsubscribe" link included in every email or by [contacting us](/contact/).
 
 ### 9.7 Privacy
 
@@ -276,7 +276,7 @@ These Terms, together with our [Privacy Policy](/legal/privacy-policy/) and any 
 For questions about these Terms, contact us at:
 
 **Coin Show Near Me**
-Email: legal@coinshownearme.com
+[Contact us here](/contact/)
 
 ---
 


### PR DESCRIPTION
## Summary

- **CTA button text fix** -- Blog and Find a Dealer pages had invisible button text (gold-on-gold). Added `cta-btn` class so the existing white-text CSS override applies correctly.
- **Contact Us page** -- New `/contact/` page with Formspree form, added to sidebar nav (nav_order: 8).
- **Inbox removed from nav** -- Excluded `inbox/` and `AGENTS.md` from Jekyll build so they no longer appear in the sidebar or as public pages.
- **Placeholder emails replaced** -- All references to `legal@coinshownearme.com` and `privacy@coinshownearme.com` (which don't exist yet) now link to the new `/contact/` page instead.
- **Legal stays at bottom** -- Already had `nav_order: 99`, no change needed.

## Sidebar nav order after this PR

1. Tools (4)
2. Guides (5)
3. Blog (6)
4. Find a Dealer (7)
5. Contact Us (8)
6. Legal (99)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.16 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-6 spent 10m and 18,628 tokens on this as a headless worker.
