### PR TITLE
GH#55: fix: restore favicon metadata

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,10 +1,12 @@
-<meta name="google-site-verification" content="ZW60JDUpZFD9rhZv8KgiklQ65RSr5jyyxku3686lHbo">
-<meta name="google-site-verification" content="DqU8VGv1svEy5GVzQoi1vn1My7ubNJgeHdBQfokkNbk">
-<link rel="icon" href="/favicon.ico" sizes="any">
+<!-- Favicon -->
+<link rel="icon" type="image/x-icon" href="/favicon.ico" sizes="any">
 <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon-16x16.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon-32x32.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="192x192" href="/assets/images/favicon-192x192.png">
+
+<meta name="google-site-verification" content="ZW60JDUpZFD9rhZv8KgiklQ65RSr5jyyxku3686lHbo">
+<meta name="google-site-verification" content="DqU8VGv1svEy5GVzQoi1vn1My7ubNJgeHdBQfokkNbk">
 {% include seo-meta.html %}
 
 <!-- Google Analytics (GA4) -->


### PR DESCRIPTION
## Summary

Recreated the useful favicon head metadata from closed PR #53 in a clean replacement branch while preserving the existing favicon asset references.

## Files Changed

_includes/head_custom.html

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** jekyll build could not run because the jekyll executable is not installed in this worker; verified _includes/head_custom.html references each favicon path and confirmed each referenced favicon file exists with python3.

Resolves #55


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.33 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1m and 45,772 tokens on this as a headless worker.