### PR TITLE
GH#61: fix: restore buffalo favicon

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,9 +1,9 @@
 <!-- Favicon -->
-<link rel="icon" type="image/x-icon" href="/favicon.ico" sizes="any">
-<link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon-16x16.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="192x192" href="/assets/images/favicon-192x192.png">
+<link rel="icon" type="image/x-icon" href="/favicon.ico">
 
 <meta name="google-site-verification" content="ZW60JDUpZFD9rhZv8KgiklQ65RSr5jyyxku3686lHbo">
 <meta name="google-site-verification" content="DqU8VGv1svEy5GVzQoi1vn1My7ubNJgeHdBQfokkNbk">


### PR DESCRIPTION
## Summary

Restored the buffalo favicon link ordering in the shared head include so the site resolves the intended icon set again.

## Files Changed

_includes/head_custom.html

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified favicon links in _includes/head_custom.html resolve to existing files with a Python check; no package.json or Gemfile build command is present in this checkout.

Resolves #61


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1m and 50,171 tokens on this as a headless worker.