### PR TITLE
Initialize aidevops features

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,56 @@
+# Agent Instructions
+
+This directory contains project-specific agent context. The [aidevops](https://aidevops.sh)
+framework is loaded separately via the global config (`~/.aidevops/agents/`).
+
+## Purpose
+
+Files in `.agents/` provide project-specific instructions that AI assistants
+read when working in this repository. Use this for:
+
+- Domain-specific conventions not covered by the framework
+- Project architecture decisions and patterns
+- API design rules, data models, naming conventions
+- Integration details (third-party services, deployment targets)
+
+## Adding Agents
+
+Create `.md` files in this directory for domain-specific context:
+
+```text
+.agents/
+  AGENTS.md              # This file - overview and index
+  api-patterns.md        # API design conventions
+  deployment.md          # Deployment procedures
+  data-model.md          # Database schema and relationships
+```
+
+Each file is read on demand by AI assistants when relevant to the task.
+
+## Security
+
+### Prompt Injection Defense
+
+Any feature that passes untrusted content to an LLM — user input, tool outputs,
+retrieved documents, emails, tickets, or webhook payloads — must defend against
+prompt injection. Sanitize and validate that content before including it in
+prompts:
+
+- Strip or escape control characters and instruction-like patterns
+- Use structured prompt templates with clear system/user boundaries
+- Never concatenate raw external content directly into system prompts
+- Validate all externally sourced content (tool results, API responses, database
+  records) before inclusion in prompts
+- Consider allowlist-based input validation where possible
+
+### General Security Rules
+
+- Never log or expose API keys, tokens, or credentials in output
+- Store secrets via `aidevops secret set <NAME>` (gopass-encrypted) or
+  environment variables — never hardcode them in source
+- Use `<PLACEHOLDER>` values in code examples; note the secure storage location
+- Validate all external input (user input, webhook payloads, API responses)
+- Pin third-party GitHub Actions to SHA hashes, not branch tags
+- Run `aidevops security audit` periodically to check security posture
+- See `~/.aidevops/agents/tools/security/prompt-injection-defender.md` for
+  the framework's prompt injection defense patterns

--- a/.aidevops.json
+++ b/.aidevops.json
@@ -1,0 +1,39 @@
+{
+  "version": "3.14.90",
+  "initialized": "2026-05-07T18:20:51Z",
+  "init_scope": "standard",
+  "agent_source": false,
+  "features": {
+    "planning": true,
+    "git_workflow": true,
+    "code_quality": true,
+    "time_tracking": true,
+    "database": false,
+    "beads": true,
+    "sops": true,
+    "security": true
+  },
+  "time_tracking": {
+    "enabled": false,
+    "prompt_on_commit": true,
+    "auto_record_branch_start": true
+  },
+  "database": {
+    "enabled": true,
+    "schema_path": "schemas",
+    "migrations_path": "migrations",
+    "seeds_path": "seeds",
+    "auto_generate_migration": true
+  },
+  "beads": {
+    "enabled": true,
+    "sync_on_commit": false,
+    "auto_ready_check": true
+  },
+  "sops": {
+    "enabled": true,
+    "backend": "age",
+    "patterns": ["*.secret.yaml", "*.secret.json", "configs/*.enc.json", "configs/*.enc.yaml"]
+  },
+  "plugins": []
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Opt out of AI model training
+* ai-training=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,3 +115,24 @@ Dashboard inbox: `~/Git/business-dashboard/inbox/`
 - **SSH:** `ssh -i ~/.ssh/hetzner_server root@204.168.137.38` (from Milo machine)
 - **CRM login:** Cloudron SSO at https://crm.cloud.ewastefreepickup.com (NOT admin/admin123)
 - **Payment:** Chase Business Preferred
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+## Beads Issue Tracker
+
+This project can use **bd (beads)** for issue tracking. Run `bd prime` when task-graph context is needed.
+
+### Quick Reference
+
+```bash
+bd ready                # Find available work
+bd show <id>            # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>           # Complete work
+```
+
+### Rules
+
+- Keep the existing inbox and project `TODO.md` workflow unless Milo explicitly asks to migrate a task into Beads.
+- Do not auto-push, merge, or deploy changes. Push only with explicit user approval.
+- Run relevant quality checks before claiming code changes are complete.
+<!-- END BEADS INTEGRATION -->

--- a/SESSION-STATE.md
+++ b/SESSION-STATE.md
@@ -1,0 +1,20 @@
+# Session State
+
+**Last updated:** 2026-05-07 11:25 PT
+**Session:** aidevops setup
+
+## Completed today
+- Started safe aidevops setup in linked worktree `coin-shows-near-me-aidevops-20260507`.
+- Added aidevops project config and AI-training opt-out attributes.
+- Enabled planning, git workflow, code quality, time tracking, beads, SOPS, and security.
+- Left database automation off because this is a static Jekyll/GitHub Pages site, not a database-backed app.
+- Removed generated local-path helper links and database folders before commit because this is a public repo.
+
+## In progress
+- Verify Coin Shows aidevops setup and decide whether to commit/push after review.
+
+## Next up
+- Review the pending Instagram inbox item manually if it becomes relevant to Coin Shows content or strategy.
+
+## Open decisions
+- SOPS is enabled for future encrypted configs, but local `sops`/`age` tools still need setup before use.

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -1,0 +1,129 @@
+---
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# Execution Plans
+
+Complex, multi-session work requiring research, design decisions, and detailed tracking.
+
+Based on [OpenAI's PLANS.md](https://cookbook.openai.com/articles/codex_exec_plans) with TOON-enhanced parsing and [Beads](https://github.com/steveyegge/beads) integration for dependency visualization.
+
+<!--TOON:meta{version,format,updated}:
+1.0,plans-md+toon,{{DATE}}
+-->
+
+## Format
+
+Each plan includes:
+- **Plan ID**: `p001`, `p002`, etc. (for cross-referencing)
+- **Status**: Planning / In Progress (Phase X/Y) / Blocked / Completed
+- **Time Estimate**: `~2w (ai:1w test:0.5w read:0.5w)`
+- **Timestamps**: `logged:`, `started:`, `completed:`
+- **Dependencies**: `blocked-by:p001` or `blocks:p003`
+- **Linkage (The Pin)**: File:line references for search hit-rate (see below)
+- **Progress**: Timestamped checkboxes with estimates and actuals
+- **Decision Log**: Key decisions with rationale
+- **Surprises & Discoveries**: Unexpected findings
+- **Outcomes & Retrospective**: Results and lessons (when complete)
+
+### Linkage (The Pin)
+
+Based on [Loom's spec-as-lookup-table pattern](https://ghuntley.com/ralph/), each plan should include a Linkage section that functions as a lookup table for AI search:
+
+| Concept | Files | Lines | Synonyms |
+|---------|-------|-------|----------|
+| {concept} | {file path} | {line range} | {related terms} |
+
+**Why this matters:**
+- Reduces hallucination by providing explicit anchors
+- Improves search hit-rate with synonyms
+- Points to exact file hunks for context
+- Prevents AI from inventing when it should reference
+
+## Active Plans
+
+<!-- Add active plans here - see Plan Template below -->
+
+<!--TOON:active_plans[0]{id,title,status,phase,total_phases,owner,tags,est,est_ai,est_test,est_read,logged,started}:
+-->
+
+## Completed Plans
+
+<!-- Move completed plans here with Outcomes & Retrospective -->
+
+<!--TOON:completed_plans[0]{id,title,owner,tags,est,actual,logged,started,completed,lead_time_days}:
+-->
+
+## Archived Plans
+
+<!-- Plans that were abandoned or superseded -->
+
+<!--TOON:archived_plans[0]{id,title,reason,logged,archived}:
+-->
+
+---
+
+## Plan Template
+
+```markdown
+### p00X: Plan Title
+
+**Status:** Planning
+**Owner:** @username
+**Tags:** #tag1 #tag2
+**Estimate:** ~Xd (ai:Xd test:Xd read:Xd)
+**Dependencies:** blocked-by:p001 (if any)
+**PRD:** [todo/tasks/prd-{slug}.md](tasks/prd-{slug}.md)
+**Tasks:** [todo/tasks/tasks-{slug}.md](tasks/tasks-{slug}.md)
+**Logged:** YYYY-MM-DD
+
+#### Purpose
+
+Brief description of why this work matters.
+
+#### Development Environment
+
+<!-- Required for Python, Node.js, and any project with non-trivial setup.
+     Workers read this section to avoid broken installs in worktrees. -->
+
+| Item | Value |
+|------|-------|
+| Language/runtime | e.g. Python 3.12, Node 20 |
+| Venv/install | e.g. `python3 -m venv .venv && pip install -e ".[dev]"` |
+| Tests | e.g. `source .venv/bin/activate && pytest` |
+| Do NOT | e.g. install globally; run `pip install -e` from worktree using canonical venv |
+
+#### Linkage (The Pin)
+
+| Concept | Files | Lines | Synonyms |
+|---------|-------|-------|----------|
+| {main concept} | src/path/file.ts | 45-120 | {term1}, {term2} |
+| {related concept} | src/path/other.ts | 12-89 | {term3}, {term4} |
+
+#### Progress
+
+- [ ] (YYYY-MM-DD HH:MMZ) Phase 1: Description ~Xh
+- [ ] (YYYY-MM-DD HH:MMZ) Phase 2: Description ~Xh
+
+#### Decision Log
+
+(Decisions recorded during implementation)
+
+#### Surprises & Discoveries
+
+(Unexpected findings during implementation)
+```
+
+---
+
+## Analytics
+
+<!--TOON:dependencies-->
+<!-- Format: child_id|relation|parent_id -->
+<!--/TOON:dependencies-->
+
+<!--TOON:analytics{total_plans,active,completed,archived,avg_lead_time_days,avg_variance_pct}:
+0,0,0,0,,
+-->


### PR DESCRIPTION
## Summary
- Add aidevops project setup for Coin Shows agent workflows.
- Enable planning, git workflow, code quality, time tracking, beads, SOPS, and security while leaving database automation off for the static Jekyll/GitHub Pages site.
- Add session recovery state, planning templates, AI-training opt-out, and safer Beads wording that keeps existing TODO/inbox workflow and requires explicit user approval before pushing.

## Verification
- `python3 -m json.tool .aidevops.json >/dev/null`
- Removed generated local-path helper links and database folders before commit because this is a public repo.
- Confirmed no live site content/layout pages are changed.

## Safety
- This changes repo/agent setup files only.
- It should not alter the public website pages, listings, spot-price workflow, or GitHub Pages output.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.90 plugin for [OpenCode](https://opencode.ai) v1.14.40 with gpt-5.5 spent 3d 21h and 6,319,311 tokens on this with the user in an interactive session.
