### PR TITLE
chore: clarify agent SSH guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,8 @@ Dashboard inbox: `~/Git/business-dashboard/inbox/`
 | EspoCRM | crm.cloud.ewastefreepickup.com | Included |
 | Email | info@ewastefreepickup.com (Cloudron mail + Gmail relay) | $0 |
 
-- **SSH:** `ssh -i ~/.ssh/hetzner_server root@204.168.137.38` (from Milo machine)
+- **SSH (AI agents):** use limited `deploy` access only when explicitly approved for WordPress work; never use root/admin SSH from an agent session.
+- **SSH (admin/root):** root access is manual-admin only, not for AI agents.
 - **CRM login:** Cloudron SSO at https://crm.cloud.ewastefreepickup.com (NOT admin/admin123)
 - **Payment:** Chase Business Preferred
 

--- a/SESSION-STATE.md
+++ b/SESSION-STATE.md
@@ -1,7 +1,7 @@
 # Session State
 
-**Last updated:** 2026-05-07 11:25 PT
-**Session:** aidevops setup
+**Last updated:** 2026-05-07 18:00 PT
+**Session:** guardrail cleanup
 
 ## Completed today
 - Started safe aidevops setup in linked worktree `coin-shows-near-me-aidevops-20260507`.
@@ -9,9 +9,10 @@
 - Enabled planning, git workflow, code quality, time tracking, beads, SOPS, and security.
 - Left database automation off because this is a static Jekyll/GitHub Pages site, not a database-backed app.
 - Removed generated local-path helper links and database folders before commit because this is a public repo.
+- Clarified `AGENTS.md` SSH guidance so AI agents do not use root/admin SSH.
 
 ## In progress
-- Verify Coin Shows aidevops setup and decide whether to commit/push after review.
+- Guardrail fix committed locally; push/merge only with explicit approval.
 
 ## Next up
 - Review the pending Instagram inbox item manually if it becomes relevant to Coin Shows content or strategy.


### PR DESCRIPTION
## Summary
- Clarifies that AI agents must not use root/admin SSH access.
- Documents root/admin SSH as manual-admin only while preserving limited deploy access guidance.

## Verification
- Documentation-only change; no build required.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.97 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gpt-5.5 spent 4d 4h and 8,010,622 tokens on this with the user in an interactive session.
